### PR TITLE
Refactor `Subscriber::RemotePublisherConn` into a `Subscription` struct

### DIFF
--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -189,6 +189,7 @@ dial:
 			logger.Error(topic, " : Failed to connect to ", pubURI, "- error: ", err)
 			return
 		}
+		defer conn.Close()
 	}
 
 	// 1. Write connection header
@@ -306,6 +307,16 @@ dial:
 		}
 	}
 
+}
+
+func newStartRemotePublisherConn(log *modular.ModuleLogger,
+	pubURI string, topic string, md5sum string,
+	msgType string, nodeID string,
+	msgChan chan messageEvent,
+	quitChan chan struct{},
+	disconnectedChan chan string, msgTypeProper MessageType) {
+	sub := newDefaultSubscription(log, pubURI, topic, md5sum, msgType, nodeID, msgChan, quitChan, disconnectedChan, msgTypeProper)
+	sub.start()
 }
 
 func setDifference(lhs []string, rhs []string) []string {

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -89,14 +89,7 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 					quitChan := make(chan struct{}, 10)
 					sub.connections[pub] = quitChan
 					sub.uri2pub[uri] = pub
-					go startRemotePublisherConn(log,
-						uri, sub.topic,
-						sub.msgType.MD5Sum(),
-						sub.msgType.Name(), nodeID,
-						sub.msgChan,
-						quitChan,
-						sub.disconnectedChan,
-						sub.msgType)
+					startRemotePublisherConn(log, uri, sub.topic, sub.msgType, nodeID, sub.msgChan, quitChan, sub.disconnectedChan)
 				} else {
 					logger.Warn(sub.topic, " : rosgo does not support protocol: ", name)
 				}
@@ -161,13 +154,12 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 // Creates a subscription to a remote publisher and runs it
 //
 func startRemotePublisherConn(log *modular.ModuleLogger,
-	pubURI string, topic string, md5sum string,
-	msgType string, nodeID string,
+	pubURI string, topic string, msgType MessageType, nodeID string,
 	msgChan chan messageEvent,
 	quitChan chan struct{},
-	disconnectedChan chan string, msgTypeProper MessageType) {
-	sub := newDefaultSubscription(log, pubURI, topic, md5sum, msgType, nodeID, msgChan, quitChan, disconnectedChan, msgTypeProper)
-	sub.start()
+	disconnectedChan chan string) {
+	sub := newDefaultSubscription(pubURI, topic, msgType, nodeID, msgChan, quitChan, disconnectedChan)
+	sub.start(log)
 }
 
 func setDifference(lhs []string, rhs []string) []string {

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -15,7 +15,7 @@ type messageEvent struct {
 	event MessageEvent
 }
 
-// The subscription object runs in own goroutine (startSubscription).
+// The subscriber object runs in own goroutine (start).
 // Do not access any properties from other goroutine.
 type defaultSubscriber struct {
 	topic            string
@@ -150,9 +150,7 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 	}
 }
 
-//
-// Creates a subscription to a remote publisher and runs it
-//
+// startRemotePublisherConn creates a subscription to a remote publisher and runs it
 func startRemotePublisherConn(log *modular.ModuleLogger,
 	pubURI string, topic string, msgType MessageType, nodeID string,
 	msgChan chan messageEvent,

--- a/ros/subscriber_benchmark_test.go
+++ b/ros/subscriber_benchmark_test.go
@@ -33,39 +33,9 @@ func BenchmarkRemotePublisherConn_Throughput1Kb(b *testing.B) {
 	teardownRemotePublisherConnBenchmark(b, l, conn, disconnectedChan)
 }
 
-func BenchmarkRemotePublisherConn_NewThroughput1Kb(b *testing.B) {
-	l, conn, msgChan, disconnectedChan := setupRemotePublisherConnBenchmark(b, newStartRemotePublisherConn)
-	defer l.Close()
-	defer conn.Close()
-
-	buffer := make([]byte, 1000) // 1 kB of data
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		sendMessageAndReceiveInChannelWithB(b, conn, msgChan, buffer)
-	}
-
-	teardownRemotePublisherConnBenchmark(b, l, conn, disconnectedChan)
-}
-
 func BenchmarkRemotePublisherConn_Throughput1Mb(b *testing.B) {
 
 	l, conn, msgChan, disconnectedChan := setupRemotePublisherConnBenchmark(b, startRemotePublisherConn)
-	defer l.Close()
-	defer conn.Close()
-
-	buffer := make([]byte, 1000000) // 1 MB of data
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		sendMessageAndReceiveInChannelWithB(b, conn, msgChan, buffer)
-	}
-
-	teardownRemotePublisherConnBenchmark(b, l, conn, disconnectedChan)
-}
-
-func BenchmarkRemotePublisherConn_NewThroughput1Mb(b *testing.B) {
-	l, conn, msgChan, disconnectedChan := setupRemotePublisherConnBenchmark(b, newStartRemotePublisherConn)
 	defer l.Close()
 	defer conn.Close()
 

--- a/ros/subscriber_benchmark_test.go
+++ b/ros/subscriber_benchmark_test.go
@@ -1,0 +1,164 @@
+package ros
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	modular "github.com/edwinhayes/logrus-modular"
+	"github.com/sirupsen/logrus"
+)
+
+func BenchmarkRemotePublisherConn_Throughput(b *testing.B) {
+	logger := modular.NewRootLogger(logrus.New())
+	topic := "/test/topic"
+	nodeID := "testNode"
+	msgChan := make(chan messageEvent)
+	quitChan := make(chan struct{})
+	disconnectedChan := make(chan string)
+	msgType := testMessageType{}
+
+	log := logger.GetModuleLogger()
+	log.SetLevel(logrus.InfoLevel)
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer l.Close()
+
+	pubURI := l.Addr().String()
+
+	go startRemotePublisherConn(
+		&log,
+		pubURI,
+		topic,
+		msgType.MD5Sum(),
+		msgType.Name(),
+		nodeID,
+		msgChan,
+		quitChan,
+		disconnectedChan,
+		msgType,
+	)
+
+	conn := connectToSubscriberWithB(b, l, topic, msgType)
+	defer conn.Close()
+
+	buffer := make([]byte, 1000000) // 1 MB of data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sendMessageAndReceiveInChannelWithB(b, conn, msgChan, buffer)
+	}
+
+	conn.Close()
+	l.Close()
+	select {
+	case <-disconnectedChan:
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		b.Fatalf("Took too long for client to disconnect from publisher")
+	}
+}
+
+func BenchmarkRemotePublisherConn_NewThroughput(b *testing.B) {
+	logger := modular.NewRootLogger(logrus.New())
+	topic := "/test/topic"
+	nodeID := "testNode"
+	msgChan := make(chan messageEvent)
+	quitChan := make(chan struct{})
+	disconnectedChan := make(chan string)
+	msgType := testMessageType{}
+
+	log := logger.GetModuleLogger()
+	log.SetLevel(logrus.InfoLevel)
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer l.Close()
+
+	pubURI := l.Addr().String()
+
+	go newStartRemotePublisherConn(
+		&log,
+		pubURI,
+		topic,
+		msgType.MD5Sum(),
+		msgType.Name(),
+		nodeID,
+		msgChan,
+		quitChan,
+		disconnectedChan,
+		msgType,
+	)
+
+	conn := connectToSubscriberWithB(b, l, topic, msgType)
+	defer conn.Close()
+
+	buffer := make([]byte, 1000000) // 1 MB of data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sendMessageAndReceiveInChannelWithB(b, conn, msgChan, buffer)
+	}
+
+	conn.Close()
+	l.Close()
+	select {
+	case <-disconnectedChan:
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		b.Fatalf("Took too long for client to disconnect from publisher")
+	}
+}
+
+func connectToSubscriberWithB(t *testing.B, l net.Listener, topic string, msgType testMessageType) net.Conn {
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = readConnectionHeader(conn)
+
+	if err != nil {
+		t.Fatal("Failed to read header:", err)
+	}
+
+	replyHeader := []header{
+		{"topic", topic},
+		{"md5sum", msgType.MD5Sum()},
+		{"type", msgType.Name()},
+		{"callerid", "testPublisher"},
+	}
+
+	err = writeConnectionHeader(replyHeader, conn)
+	if err != nil {
+		t.Fatalf("Failed to write header: %s", replyHeader)
+	}
+
+	return conn
+}
+
+func sendMessageAndReceiveInChannelWithB(t *testing.B, conn net.Conn, msgChan chan messageEvent, buffer []byte) {
+
+	err := binary.Write(conn, binary.LittleEndian, uint32(len(buffer)))
+	if err != nil {
+		t.Fatalf("Failed to write message size, err: %s", err)
+	}
+	n, err := conn.Write(buffer) // payload
+	if n != len(buffer) || err != nil {
+		t.Fatalf("Failed to write message payload, n: %d : err: %s", n, err)
+	}
+
+	select {
+	case <-msgChan:
+		// Assume the message is fine - we have unit tests for that!
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		t.Fatalf("Did not receive message from channel")
+	}
+}

--- a/ros/subscriber_benchmark_test.go
+++ b/ros/subscriber_benchmark_test.go
@@ -117,7 +117,7 @@ func sendMessageAndReceiveInChannelWithB(t *testing.B, conn net.Conn, msgChan ch
 	if err != nil {
 		t.Fatalf("Failed to write message size, err: %s", err)
 	}
-	n, err := conn.Write(buffer) // payload
+	n, err := conn.Write(buffer) // Write the payload.
 	if n != len(buffer) || err != nil {
 		t.Fatalf("Failed to write message payload, n: %d : err: %s", n, err)
 	}

--- a/ros/subscriber_benchmark_test.go
+++ b/ros/subscriber_benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkRemotePublisherConn_Throughput1Kb(b *testing.B) {
 	defer l.Close()
 	defer conn.Close()
 
-	buffer := make([]byte, 1000) // 1 kB of data
+	buffer := make([]byte, 1000) // 1 kB of data.
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -34,7 +34,7 @@ func BenchmarkRemotePublisherConn_Throughput1Mb(b *testing.B) {
 	defer l.Close()
 	defer conn.Close()
 
-	buffer := make([]byte, 1000000) // 1 MB of data
+	buffer := make([]byte, 1000000) // 1 MB of data.
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -46,9 +46,7 @@ func BenchmarkRemotePublisherConn_Throughput1Mb(b *testing.B) {
 
 // Benchmark helpers
 
-//
-// Setup, establishes all init values and kicks off the start function
-//
+// setupRemotePublisherConnBenchmark establishes all init values and kicks off the subscriber.
 func setupRemotePublisherConnBenchmark(b *testing.B, start startRemotePublisher) (net.Listener, net.Conn, chan messageEvent, chan string) {
 	logger := modular.NewRootLogger(logrus.New())
 	topic := "/test/topic"
@@ -72,9 +70,7 @@ func setupRemotePublisherConnBenchmark(b *testing.B, start startRemotePublisher)
 	return l, conn, msgChan, disconnectedChan
 }
 
-//
-// Teardown, take down TCP connections and ensures the remotePublisherConn disconnects as expected
-//
+// teardownRemotePublisherConnBenchmark, safely bring down TCP connections and ensure the remotePublisherConn disconnects as expected.
 func teardownRemotePublisherConnBenchmark(b *testing.B, l net.Listener, conn net.Conn, disconnectedChan chan string) {
 	conn.Close()
 	l.Close()
@@ -86,9 +82,7 @@ func teardownRemotePublisherConnBenchmark(b *testing.B, l net.Listener, conn net
 	}
 }
 
-//
-// Connects the test "publisher" to the subscriber, exectutes a header exchange
-//
+// connectToSubscriberWithB connects the test "publisher" to the subscriber under test so that it is ready to receive messages.
 func connectToSubscriberWithB(t *testing.B, l net.Listener, topic string, msgType testMessageType) net.Conn {
 	conn, err := l.Accept()
 	if err != nil {
@@ -116,9 +110,7 @@ func connectToSubscriberWithB(t *testing.B, l net.Listener, topic string, msgTyp
 	return conn
 }
 
-//
-// Sends a message to the subscriber with a set number of bytes
-//
+// sendMessageAndReceiveInChannelWithB publishes a message to the subscriber through the tcp stream.
 func sendMessageAndReceiveInChannelWithB(t *testing.B, conn net.Conn, msgChan chan messageEvent, buffer []byte) {
 
 	err := binary.Write(conn, binary.LittleEndian, uint32(len(buffer)))
@@ -132,7 +124,7 @@ func sendMessageAndReceiveInChannelWithB(t *testing.B, conn net.Conn, msgChan ch
 
 	select {
 	case <-msgChan:
-		// Assume the message is fine - we have unit tests for that!
+		// Assume the message is fine - we have unit tests to verify this.
 		return
 	case <-time.After(time.Duration(100) * time.Millisecond):
 		t.Fatalf("Did not receive message from channel")

--- a/ros/subscriber_benchmark_test.go
+++ b/ros/subscriber_benchmark_test.go
@@ -10,12 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type startRemotePublisher func(*modular.ModuleLogger,
-	string, string, string,
-	string, string,
-	chan messageEvent,
-	chan struct{},
-	chan string, MessageType)
+type startRemotePublisher func(*modular.ModuleLogger, string, string, MessageType, string, chan messageEvent, chan struct{}, chan string)
 
 func BenchmarkRemotePublisherConn_Throughput1Kb(b *testing.B) {
 
@@ -71,18 +66,7 @@ func setupRemotePublisherConnBenchmark(b *testing.B, start startRemotePublisher)
 		b.Fatal(err)
 	}
 
-	go start(
-		&log,
-		l.Addr().String(),
-		topic,
-		msgType.MD5Sum(),
-		msgType.Name(),
-		nodeID,
-		msgChan,
-		quitChan,
-		disconnectedChan,
-		msgType,
-	)
+	start(&log, l.Addr().String(), topic, msgType, nodeID, msgChan, quitChan, disconnectedChan)
 
 	conn := connectToSubscriberWithB(b, l, topic, msgType)
 	return l, conn, msgChan, disconnectedChan

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -89,10 +89,10 @@ func TestRemotePublisherConn_ClosesFromSignal(t *testing.T) {
 	conn := connectToSubscriber(t, l, topic, msgType)
 	defer conn.Close()
 
-	// Signal to close
+	// Signal to close.
 	quitChan <- struct{}{}
 
-	// Check that buffer closed
+	// Check that buffer closed.
 	buffer := make([]byte, 1)
 	conn.SetDeadline(time.Now().Add(100 * time.Millisecond))
 	_, err = conn.Read(buffer)

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -68,7 +68,7 @@ func TestRemotePublisherConn_DoesConnect(t *testing.T) {
 
 	pubURI := l.Addr().String()
 
-	go newStartRemotePublisherConn(
+	go startRemotePublisherConn(
 		&log,
 		pubURI,
 		topic,
@@ -156,7 +156,7 @@ func TestRemotePublisherConn_ClosesFromSignal(t *testing.T) {
 
 	pubURI := l.Addr().String()
 
-	go newStartRemotePublisherConn(
+	go startRemotePublisherConn(
 		&log,
 		pubURI,
 		topic,
@@ -208,7 +208,7 @@ func TestRemotePublisherConn_RemoteReceivesData(t *testing.T) {
 
 	pubURI := l.Addr().String()
 
-	go newStartRemotePublisherConn(
+	go startRemotePublisherConn(
 		&log,
 		pubURI,
 		topic,

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -68,18 +68,7 @@ func TestRemotePublisherConn_DoesConnect(t *testing.T) {
 
 	pubURI := l.Addr().String()
 
-	go startRemotePublisherConn(
-		&log,
-		pubURI,
-		topic,
-		msgType.MD5Sum(),
-		msgType.Name(),
-		nodeID,
-		msgChan,
-		quitChan,
-		disconnectedChan,
-		msgType,
-	)
+	startRemotePublisherConn(&log, pubURI, topic, msgType, nodeID, msgChan, quitChan, disconnectedChan)
 
 	conn, err := l.Accept()
 	if err != nil {
@@ -156,18 +145,7 @@ func TestRemotePublisherConn_ClosesFromSignal(t *testing.T) {
 
 	pubURI := l.Addr().String()
 
-	go startRemotePublisherConn(
-		&log,
-		pubURI,
-		topic,
-		msgType.MD5Sum(),
-		msgType.Name(),
-		nodeID,
-		msgChan,
-		quitChan,
-		disconnectedChan,
-		msgType,
-	)
+	startRemotePublisherConn(&log, pubURI, topic, msgType, nodeID, msgChan, quitChan, disconnectedChan)
 
 	conn := connectToSubscriber(t, l, topic, msgType)
 	defer conn.Close()
@@ -208,18 +186,7 @@ func TestRemotePublisherConn_RemoteReceivesData(t *testing.T) {
 
 	pubURI := l.Addr().String()
 
-	go startRemotePublisherConn(
-		&log,
-		pubURI,
-		topic,
-		msgType.MD5Sum(),
-		msgType.Name(),
-		nodeID,
-		msgChan,
-		quitChan,
-		disconnectedChan,
-		msgType,
-	)
+	startRemotePublisherConn(&log, pubURI, topic, msgType, nodeID, msgChan, quitChan, disconnectedChan)
 
 	conn := connectToSubscriber(t, l, topic, msgType)
 	defer conn.Close()

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -25,7 +25,7 @@ func (t testMessageType) Text() string {
 }
 
 func (t testMessageType) MD5Sum() string {
-	return "fakeMD5"
+	return "0123456789abcdeffedcba9876543210"
 }
 
 func (t testMessageType) Name() string {

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -1,0 +1,237 @@
+package ros
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	modular "github.com/edwinhayes/logrus-modular"
+	"github.com/sirupsen/logrus"
+)
+
+//
+// Set up testMessage fakes
+//
+type testMessageType struct{}
+type testMessage struct{}
+
+var _ MessageType = testMessageType{}
+var _ Message = testMessage{}
+
+func (t testMessageType) Text() string {
+	return "test_message_type"
+}
+
+func (t testMessageType) MD5Sum() string {
+	return "fakeMD5"
+}
+
+func (t testMessageType) Name() string {
+	return "test_message"
+}
+
+func (t testMessageType) NewMessage() Message {
+	return &testMessage{}
+}
+
+func (t testMessage) Type() MessageType {
+	return &testMessageType{}
+}
+
+func (t testMessage) Serialize(buf *bytes.Buffer) error {
+	return nil
+}
+
+func (t testMessage) Deserialize(buf *bytes.Reader) error {
+	return nil
+}
+
+func TestRemoteConnects(t *testing.T) {
+	logger := modular.NewRootLogger(logrus.New())
+
+	topic := "/test/topic"
+	nodeID := "testNode"
+	msgChan := make(chan messageEvent)
+	quitChan := make(chan struct{})
+	disconnectedChan := make(chan string)
+	msgType := testMessageType{}
+
+	log := logger.GetModuleLogger()
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	pubURI := l.Addr().String()
+
+	go startRemotePublisherConn(
+		&log,
+		pubURI,
+		topic,
+		msgType.MD5Sum(),
+		msgType.Name(),
+		nodeID,
+		msgChan,
+		quitChan,
+		disconnectedChan,
+		msgType,
+	)
+
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	resHeaders, err := readConnectionHeader(conn)
+
+	if err != nil {
+		t.Fatal("Failed to read header:", err)
+	}
+
+	resHeaderMap := make(map[string]string)
+	for _, h := range resHeaders {
+		resHeaderMap[h.key] = h.value
+	}
+
+	if resHeaderMap["md5sum"] != msgType.MD5Sum() {
+		t.Fatalf("Incorrect MD5 sum %s", resHeaderMap["md5sum"])
+	}
+
+	if resHeaderMap["topic"] != topic {
+		t.Fatalf("Incorrect topic: %s", topic)
+	}
+
+	if resHeaderMap["type"] != msgType.Name() {
+		t.Fatalf("Incorrect type: %s", resHeaderMap["type"])
+	}
+
+	if resHeaderMap["callerid"] != "testNode" {
+		t.Fatalf("Incorrect caller ID: %s", resHeaderMap["testNode"])
+	}
+
+	replyHeader := []header{
+		{"topic", topic},
+		{"md5sum", msgType.MD5Sum()},
+		{"type", msgType.Name()},
+		{"callerid", "testPublisher"},
+	}
+
+	err = writeConnectionHeader(replyHeader, conn)
+	if err != nil {
+		t.Fatalf("Failed to write header: %s", replyHeader)
+	}
+
+	conn.Close()
+	l.Close()
+	select {
+	case <-disconnectedChan:
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		t.Fatalf("Took too long for client to disconnect from publisher")
+	}
+}
+
+func TestRemoteReceivesData(t *testing.T) {
+	logger := modular.NewRootLogger(logrus.New())
+
+	topic := "/test/topic"
+	nodeID := "testNode"
+	msgChan := make(chan messageEvent)
+	quitChan := make(chan struct{})
+	disconnectedChan := make(chan string)
+	msgType := testMessageType{}
+
+	log := logger.GetModuleLogger()
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	pubURI := l.Addr().String()
+
+	go startRemotePublisherConn(
+		&log,
+		pubURI,
+		topic,
+		msgType.MD5Sum(),
+		msgType.Name(),
+		nodeID,
+		msgChan,
+		quitChan,
+		disconnectedChan,
+		msgType,
+	)
+
+	conn := connectToSubscriber(t, l, topic, msgType)
+	defer conn.Close()
+
+	// Size = 2 bytes
+	n, err := conn.Write([]byte{0x02, 0x00, 0x00, 0x00})
+	if n != 4 || err != nil {
+		t.Fatalf("Failed to write message size, n: %d : err: %s", n, err)
+	}
+	n, err = conn.Write([]byte{0x34, 0x12}) // payload
+	if n != 2 || err != nil {
+		t.Fatalf("Failed to write message payload, n: %d : err: %s", n, err)
+	}
+
+	select {
+	case message := <-msgChan:
+
+		if message.event.PublisherName != "testPublisher" {
+			t.Fatalf("Published with the wrong publisher name: %s", message.event.PublisherName)
+		}
+		if len(message.bytes) != 2 {
+			t.Fatalf("Payload size is incorrect: %d", len(message.bytes))
+		}
+		if message.bytes[0] != 0x34 || message.bytes[1] != 0x12 {
+			t.Fatalf("Published the wrong payload: %x:02 %x:02", message.bytes[0], message.bytes[1])
+		}
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		t.Fatalf("Took too long for client to disconnect from publisher")
+	}
+
+	conn.Close()
+	l.Close()
+	select {
+	case <-disconnectedChan:
+		t.Log(disconnectedChan)
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		t.Fatalf("Took too long for client to disconnect from publisher")
+	}
+}
+
+func connectToSubscriber(t *testing.T, l net.Listener, topic string, msgType testMessageType) net.Conn {
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = readConnectionHeader(conn)
+
+	if err != nil {
+		t.Fatal("Failed to read header:", err)
+	}
+
+	replyHeader := []header{
+		{"topic", topic},
+		{"md5sum", msgType.MD5Sum()},
+		{"type", msgType.Name()},
+		{"callerid", "testPublisher"},
+	}
+
+	err = writeConnectionHeader(replyHeader, conn)
+	if err != nil {
+		t.Fatalf("Failed to write header: %s", replyHeader)
+	}
+
+	return conn
+}

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -78,7 +78,14 @@ func (s *defaultSubscription) start() {
 
 	for {
 		// Connect
-		s.connectToPublisher(&conn)
+		if s.connectToPublisher(&conn) == false {
+			if conn != nil {
+				conn.Close()
+			}
+			logger.Debug(s.topic, " : Connection closed, reconnecting with publisher")
+			return
+		}
+		defer conn.Close() // Make sure we close this
 
 		// Reading from publisher
 		connectionState := s.readFromPublisher(conn)

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -1,0 +1,279 @@
+package ros
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"time"
+
+	modular "github.com/edwinhayes/logrus-modular"
+)
+
+// The subscription object runs in own goroutine (startSubscription).
+// Do not access any properties from other goroutine.
+type defaultSubscription struct {
+	logger                 *modular.ModuleLogger
+	pubURI                 string
+	topic                  string
+	md5sum                 string
+	msgType                string
+	nodeID                 string
+	messageChan            chan messageEvent
+	requestStopChan        chan struct{} // tell the subscription to disconnect
+	remoteDisconnectedChan chan string   // tell the subscriber that the remote has disconnected
+	msgTypeProper          MessageType
+	event                  MessageEvent
+	pool                   []byte
+}
+
+func newDefaultSubscription(logger *modular.ModuleLogger,
+	pubURI string, topic string, md5sum string,
+	msgType string, nodeID string,
+	messageChan chan messageEvent,
+	requestStopChan chan struct{},
+	remoteDisconnectedChan chan string, msgTypeProper MessageType) *defaultSubscription {
+
+	return &defaultSubscription{
+		logger:                 logger,
+		pubURI:                 pubURI,
+		topic:                  topic,
+		md5sum:                 md5sum,
+		msgType:                msgType,
+		nodeID:                 nodeID,
+		messageChan:            messageChan,
+		requestStopChan:        requestStopChan,
+		remoteDisconnectedChan: remoteDisconnectedChan,
+		msgTypeProper:          msgTypeProper,
+	}
+}
+
+type connectionState int
+
+const (
+	publisherDisconnected connectionState = iota
+	tcpOutOfSync
+	connectionFailure
+	stopRequested
+)
+
+type readResult int
+
+const (
+	readOk readResult = iota
+	readFailed
+	readTimeout
+	remoteDisconnected
+	readOutOfSync
+)
+
+func (s *defaultSubscription) start() {
+	logger := *s.logger
+	logger.Debug(s.topic, " : defaultSubscription.start()")
+
+	defer func() {
+		logger.Debug(s.topic, " : defaultSubscription.start() exit")
+	}()
+
+	var conn net.Conn
+
+	for {
+		// Connect
+		s.connectToPublisher(&conn)
+
+		// Reading from publisher
+		connectionState := s.readFromPublisher(conn)
+
+		// Under healthy conditions, we don't get here
+		// handle the returned connection state
+
+		// TCP out of sync; we will attempt to resync by closing the connection and trying again
+		if connectionState == tcpOutOfSync {
+			conn.Close()
+			logger.Debug(s.topic, " : Connection closed, reconnecting with publisher")
+		}
+
+		// A stop was externally requested - easy one!
+		if connectionState == stopRequested {
+			return
+		}
+
+		// Publisher disconnected - not much we can do here, the subscription has ended
+		if connectionState == publisherDisconnected {
+			logger.Infof("Publisher %s on topic %s disconnected", s.pubURI, s.topic)
+			s.remoteDisconnectedChan <- s.pubURI
+			return
+		}
+
+		// Connection Failure is caused by read failures; the reason is uncertain, so we will give up
+		if connectionState == connectionFailure {
+			logger.Error(s.topic, " : Failed to read a message size")
+			s.remoteDisconnectedChan <- s.pubURI
+			return
+		}
+	}
+
+}
+
+func (s *defaultSubscription) connectToPublisher(conn *net.Conn) bool {
+	var err error
+
+	logger := *s.logger
+
+	select {
+	case <-time.After(time.Duration(3000) * time.Millisecond):
+		logger.Error(s.topic, " : Failed to connect to ", s.pubURI, "timed out")
+		return false
+	default:
+		*conn, err = net.Dial("tcp", s.pubURI)
+		if err != nil {
+			logger.Error(s.topic, " : Failed to connect to ", s.pubURI, "- error: ", err)
+			return false
+		}
+	}
+
+	// 1. Write connection header
+	var headers []header
+	headers = append(headers, header{"topic", s.topic})
+	headers = append(headers, header{"md5sum", s.md5sum})
+	headers = append(headers, header{"type", s.msgType})
+	headers = append(headers, header{"callerid", s.nodeID})
+	logger.Debug(s.topic, " : TCPROS Connection Header")
+	for _, h := range headers {
+		logger.Debugf("          `%s` = `%s`", h.key, h.value)
+	}
+	err = writeConnectionHeader(headers, *conn)
+	if err != nil {
+		logger.Error(s.topic, " : Failed to write connection header.")
+		return false
+	}
+
+	// 2. Read reponse header
+	var resHeaders []header
+	resHeaders, err = readConnectionHeader(*conn)
+	if err != nil {
+		logger.Error(s.topic, " : Failed to read response header.")
+		return false
+	}
+	logger.Debug(s.topic, " : TCPROS Response Header:")
+	resHeaderMap := make(map[string]string)
+	for _, h := range resHeaders {
+		resHeaderMap[h.key] = h.value
+		logger.Debugf("          `%s` = `%s`", h.key, h.value)
+	}
+
+	if resHeaderMap["type"] != s.msgType || resHeaderMap["md5sum"] != s.md5sum {
+		logger.Error("Incompatible message type for ", s.topic, ": ", resHeaderMap["type"], ":", s.msgType, " ", resHeaderMap["md5sum"], ":", s.md5sum)
+		return false
+	}
+
+	// Some incomplete TCPROS implementations do not include topic name in response
+	if resHeaderMap["topic"] == "" {
+		resHeaderMap["topic"] = s.topic
+	}
+
+	s.event = MessageEvent{ // Event struct to be sent with each message.
+		PublisherName:    resHeaderMap["callerid"],
+		ConnectionHeader: resHeaderMap,
+	}
+	return true
+}
+
+func (s *defaultSubscription) readFromPublisher(conn net.Conn) connectionState {
+	readingSize := true
+	var msgSize int
+	var buffer []byte
+	var result readResult
+	for {
+		select {
+		case <-s.requestStopChan:
+			return stopRequested
+		default:
+			conn.SetDeadline(time.Now().Add(1000 * time.Millisecond))
+			if readingSize {
+				msgSize, result = readSize(conn)
+
+				if result == readOk {
+					readingSize = false
+					continue
+				}
+
+				if result == readTimeout {
+					// TODO: This is pretty shaky... what if we only got a portion of the size bytes?
+					//       I think we can do better
+					continue // try again!
+				}
+
+			} else {
+				buffer, result = s.readRawMessage(conn, msgSize)
+
+				if result == readOk {
+					s.event.ReceiptTime = time.Now()
+					select {
+					case s.messageChan <- messageEvent{bytes: buffer, event: s.event}:
+					case <-time.After(time.Duration(30) * time.Millisecond):
+						//logger.Debug("dropping message")
+					}
+					readingSize = true
+				}
+
+				if result == readTimeout {
+					return tcpOutOfSync // it is likely this is the case now
+				}
+			}
+
+			// Common read result cases
+			if result == readOutOfSync {
+				return tcpOutOfSync
+			}
+			if result == readFailed {
+				return connectionFailure
+			}
+			if result == remoteDisconnected {
+				return publisherDisconnected
+			}
+		}
+	}
+}
+
+func readSize(r io.Reader) (int, readResult) {
+	var msgSize uint32
+
+	err := binary.Read(r, binary.LittleEndian, &msgSize)
+	if err != nil {
+		return 0, errorToReadResult(err)
+	}
+	// Check reasonable buffer size
+	if msgSize < 256000000 {
+		return int(msgSize), readOk
+	} else {
+		// We assume that this many bytes means we are out of sync
+		return 0, readOutOfSync
+	}
+}
+
+func (s *defaultSubscription) readRawMessage(r io.Reader, size int) ([]byte, readResult) {
+	// first construct a buffer, only reallocate our pool if we need to
+	if len(s.pool) < size {
+		s.pool = make([]byte, size)
+	}
+	buffer := s.pool[:size]
+
+	_, err := io.ReadFull(r, buffer)
+	if err != nil {
+		return buffer, errorToReadResult(err)
+	}
+
+	return buffer, readOk
+}
+
+func errorToReadResult(err error) readResult {
+	if err == io.EOF {
+		return remoteDisconnected
+	}
+	if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
+		return readTimeout
+	}
+	// Not sure what the cause was - return failure at this point
+	return readFailed
+
+}

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -82,7 +82,7 @@ func (s *defaultSubscription) start() {
 			if conn != nil {
 				conn.Close()
 			}
-			logger.Debug(s.topic, " : Connection closed, reconnecting with publisher")
+			logger.Info(s.topic, " : Could not connect to publisher, closing connection")
 			return
 		}
 		defer conn.Close() // Make sure we close this

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -211,7 +211,7 @@ func (s *defaultSubscription) readFromPublisher(conn net.Conn) connectionFailure
 				}
 
 				if result == readTimeout {
-					continue // try again!
+					continue // Try again!
 				}
 
 			} else {
@@ -263,7 +263,7 @@ func readSize(r io.Reader) (int, readResult) {
 	return 0, readOutOfSync
 }
 
-// readRawMessage reads ROS message bytes from the io.Reader
+// readRawMessage reads ROS message bytes from the io.Reader.
 func (s *defaultSubscription) readRawMessage(r io.Reader, size int) ([]byte, readResult) {
 	// First, ensure our pool is large enough to receive the bytes. It is reallocated if it is too small.
 	if len(s.pool) < size {
@@ -280,9 +280,7 @@ func (s *defaultSubscription) readRawMessage(r io.Reader, size int) ([]byte, rea
 	return buffer, readOk
 }
 
-//
-// Convert errors to readResult to be handled up the callstack
-//
+// errorToReadResult converts errors to readResult to be handled further up the callstack.
 func errorToReadResult(err error) readResult {
 	if err == io.EOF {
 		return remoteDisconnected
@@ -290,6 +288,6 @@ func errorToReadResult(err error) readResult {
 	if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
 		return readTimeout
 	}
-	// Not sure what the cause was - return failure at this point
+	// Not sure what the cause was - it is just a generic readFailure.
 	return readFailed
 }

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -17,8 +17,8 @@ type defaultSubscription struct {
 	msgType                MessageType
 	nodeID                 string
 	messageChan            chan messageEvent
-	requestStopChan        chan struct{} // tell the subscription to disconnect
-	remoteDisconnectedChan chan string   // tell the subscriber that the remote has disconnected
+	requestStopChan        chan struct{} // Inbound signal for subscription to disconnect.
+	remoteDisconnectedChan chan string   // Outbound signal to indicate a disconnected channel.
 	event                  MessageEvent
 	pool                   []byte
 }
@@ -234,7 +234,7 @@ func (s *defaultSubscription) readFromPublisher(conn net.Conn) connectionFailure
 					select {
 					case s.messageChan <- messageEvent{bytes: buffer, event: s.event}:
 					case <-time.After(time.Duration(30) * time.Millisecond):
-						// Dropping message
+						// Dropping message.
 					}
 					readingSize = true
 				}
@@ -245,7 +245,7 @@ func (s *defaultSubscription) readFromPublisher(conn net.Conn) connectionFailure
 				}
 			}
 
-			// Handle read result cases
+			// Handle read result cases.
 			if result == readOutOfSync {
 				return tcpOutOfSync
 			}

--- a/ros/subscription_test.go
+++ b/ros/subscription_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Helper structs
+// Helper structs.
 
 // Set up testMessage fakes.
 type testMessageType struct{}
@@ -388,7 +388,7 @@ func writeAndVerifyPublisherHeader(t *testing.T, conn net.Conn, subscription *de
 		t.Fatalf("Failed to write header: %s", replyHeader)
 	}
 
-	// wait for the subscription to receive the data
+	// Wait for the subscription to receive the data.
 	<-time.After(time.Millisecond)
 
 	for _, expected := range replyHeader {

--- a/ros/subscription_test.go
+++ b/ros/subscription_test.go
@@ -1,0 +1,246 @@
+package ros
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	modular "github.com/edwinhayes/logrus-modular"
+	"github.com/sirupsen/logrus"
+)
+
+//
+// Uses `testMessageType` and `testMessage` defined in `subscriber_test.go`
+// Integration of subscriptions is tested in the RemotePublisherConn tests in `subscriber_test.go`
+//
+
+//
+// testReader
+//
+type testReader struct {
+	buffer []byte
+	n      int
+	err    error
+}
+
+func (r *testReader) Read(buf []byte) (n int, err error) {
+	_ = copy(buf, r.buffer)
+	n = r.n
+	err = r.err
+	return
+}
+
+var _ io.Reader = &testReader{} // verify that testReader satisfies the reader interface
+
+func getTestSubscription(pubURI string) *defaultSubscription {
+	logger := modular.NewRootLogger(logrus.New())
+
+	topic := "/test/topic"
+	nodeID := "testNode"
+	messageChan := make(chan messageEvent)
+	requestStopChan := make(chan struct{})
+	remoteDisconnectedChan := make(chan string)
+	msgType := testMessageType{}
+
+	log := logger.GetModuleLogger()
+
+	return newDefaultSubscription(&log,
+		pubURI, topic, msgType.MD5Sum(),
+		msgType.Name(), nodeID,
+		messageChan,
+		requestStopChan,
+		remoteDisconnectedChan, msgType)
+}
+
+//
+// Read Size tests
+//
+
+func TestSubscription_ReadSize(t *testing.T) {
+	type testCase struct {
+		buffer   []byte
+		expected int
+	}
+
+	testCases := []testCase{
+		{[]byte{0x00, 0x00, 0x00, 0x00}, 0},
+		{[]byte{0x01, 0x00, 0x00, 0x00}, 1},
+		{[]byte{0x0F, 0x00, 0x00, 0x00}, 15},
+		{[]byte{0x00, 0x01, 0x00, 0x00}, 256},
+		{[]byte{0xa1, 0x86, 0x01, 0x00}, 100001},
+	}
+
+	for _, tc := range testCases {
+		reader := testReader{tc.buffer, 4, nil}
+		n, res := readSize(&reader)
+		if res != readOk {
+			t.Fatalf("Expected read result %d, but got %d", readOk, res)
+		}
+		if n != tc.expected {
+			t.Fatalf("ReadSize failed, expected %d, got %d", tc.expected, n)
+		}
+
+	}
+}
+
+// Error cases
+func TestSubscription_ReadSize_TooLarge(t *testing.T) {
+	reader := testReader{[]byte{0x00, 0x00, 0x00, 0x80}, 4, nil}
+	_, res := readSize(&reader)
+	if res != readOutOfSync {
+		t.Fatalf("Expected read result %d, but got %d", readOutOfSync, res)
+	}
+}
+
+func TestSubscription_ReadSize_disconnected(t *testing.T) {
+	reader := testReader{[]byte{}, 0, io.EOF}
+	_, res := readSize(&reader)
+	if res != remoteDisconnected {
+		t.Fatalf("Expected read result %d, but got %d", remoteDisconnected, res)
+	}
+}
+
+func TestSubscription_ReadSize_otherError(t *testing.T) {
+	reader := testReader{[]byte{}, 0, errors.New("MysteryError")}
+	_, res := readSize(&reader)
+	if res != readFailed {
+		t.Fatalf("Expected read result %d, but got %d", readFailed, res)
+	}
+}
+
+//
+// Read Raw Data tests
+//
+
+// Checks pool buffer resizing logic
+func TestSubscription_ReadRawData_PoolBuffer(t *testing.T) {
+	subscription := getTestSubscription("testUri")
+	if len(subscription.pool) != 0 {
+		t.Fatalf("Expected pool size of 0, but got %d", len(subscription.pool))
+	}
+
+	reader := testReader{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 4, nil}
+
+	// Test 1, read 4 bytes, pool size goes to 4 bytes
+	reader.n = 4
+	_, _ = subscription.readRawMessage(&reader, 4)
+	if len(subscription.pool) != 4 {
+		t.Fatalf("Expected pool size of 4, but got %d", len(subscription.pool))
+	}
+
+	// Test 2, read 2 bytes, pool size stays at 4 bytes
+	reader.n = 2
+	_, _ = subscription.readRawMessage(&reader, 2)
+	if len(subscription.pool) != 4 {
+		t.Fatalf("Expected pool size of 4, but got %d", len(subscription.pool))
+	}
+
+	// Test 3, read 10 bytes, pool size goes to 10 bytes
+	reader.n = 10
+	_, _ = subscription.readRawMessage(&reader, 10)
+	if len(subscription.pool) != 10 {
+		t.Fatalf("Expected pool size of 10, but got %d", len(subscription.pool))
+	}
+}
+
+// checks basic buffer reading works correctly
+func TestSubscription_ReadRawData_ReadData(t *testing.T) {
+	subscription := getTestSubscription("testUri")
+
+	reader := testReader{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 10, nil}
+
+	buf, res := subscription.readRawMessage(&reader, 4)
+	if res != readOk {
+		t.Fatalf("Expected read result %d, but got %d", readOk, res)
+	}
+
+	for i := 0; i < len(buf); i++ {
+		if buf[i] != reader.buffer[i] {
+			t.Fatalf("Expected read buf[%d] = %x, but got %x", i, reader.buffer[i], buf[i])
+		}
+	}
+}
+
+// checks handling disconnections
+func TestSubscription_ReadRawData_disconnected(t *testing.T) {
+	subscription := getTestSubscription("testUri")
+
+	reader := testReader{[]byte{}, 0, io.EOF}
+
+	_, res := subscription.readRawMessage(&reader, 4)
+	if res != remoteDisconnected {
+		t.Fatalf("Expected read result %d, but got %d", remoteDisconnected, res)
+	}
+}
+
+//
+// Basic integration stuff - TODO: figure out how to tidy this up...
+//
+func TestSubscription_NewSubscription(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	pubURI := l.Addr().String()
+
+	subscription := getTestSubscription(pubURI)
+
+	go subscription.start()
+
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	resHeaders, err := readConnectionHeader(conn)
+
+	if err != nil {
+		t.Fatal("Failed to read header:", err)
+	}
+
+	resHeaderMap := make(map[string]string)
+	for _, h := range resHeaders {
+		resHeaderMap[h.key] = h.value
+	}
+
+	if resHeaderMap["md5sum"] != subscription.msgTypeProper.MD5Sum() {
+		t.Fatalf("Incorrect MD5 sum %s", resHeaderMap["md5sum"])
+	}
+
+	if resHeaderMap["topic"] != subscription.topic {
+		t.Fatalf("Incorrect topic: %s", subscription.topic)
+	}
+
+	if resHeaderMap["type"] != subscription.msgTypeProper.Name() {
+		t.Fatalf("Incorrect type: %s", resHeaderMap["type"])
+	}
+
+	if resHeaderMap["callerid"] != "testNode" {
+		t.Fatalf("Incorrect caller ID: %s", resHeaderMap["testNode"])
+	}
+
+	replyHeader := []header{
+		{"topic", subscription.topic},
+		{"md5sum", subscription.msgTypeProper.MD5Sum()},
+		{"type", subscription.msgTypeProper.Name()},
+		{"callerid", "testPublisher"},
+	}
+
+	err = writeConnectionHeader(replyHeader, conn)
+	if err != nil {
+		t.Fatalf("Failed to write header: %s", replyHeader)
+	}
+
+	conn.Close()
+	l.Close()
+	select {
+	case <-subscription.remoteDisconnectedChan:
+		return
+	case <-time.After(time.Duration(100) * time.Millisecond):
+		t.Fatalf("Took too long for client to disconnect from publisher")
+	}
+}


### PR DESCRIPTION
`Subscriber` has a go routine called `startRemotePublisherConn` which is responsible for:
- establishing a connection with a publisher on a specific topic
- packetising incoming data
- handling errors
- Attempting to recover from recoverable states

In order to place flow control at the root of the agent's subscriptions; this part of the code has been refactored so that:
- the flow control feature can be implemented safely without inadvertently breaking functionality
- the performance of the subscription can be monitored (so we know we at least aren't making it worse) 

### Improvements
- breaks `startRemotePublisherConn` out into a `Subscription` object
  - Added a serious amount of unit tests
- removed a couple of nasty bugs
  - previous code didn't take into account that `int` is 32-bit for a bunch of embedded linux systems; this means that the `int(msgSize) < 256000000` filter will still let quite a few very large (up to 4GB) packets be created (since these will become negative numbers on the cast... so they will pass the size limit!)
  - Fixed the `conn` object not actually getting closed when the `quitChan` channel is called
- Removed a `goto` 
- Achieved some performance improvement by using a pooled buffer rather than allocating new buffers every time a new message is received:
```
hoani@rocos-mint-vm:~/git/rosgo/ros (improvement/refactorSubscription)
└─ $ ▶ go test -bench . 
goos: linux
goarch: amd64
pkg: github.com/team-rocos/rosgo/ros
BenchmarkRemotePublisherConn_Throughput1Kb-2
   70639             14819 ns/op
BenchmarkRemotePublisherConn_NewThroughput1Kb-2       
   84954             13763 ns/op
BenchmarkRemotePublisherConn_Throughput1Mb-2
    3025            389229 ns/op
BenchmarkRemotePublisherConn_NewThroughput1Mb-2
    6218            187738 ns/op
PASS
ok      github.com/team-rocos/rosgo/ros 9.057s
``` 

### Concerns

This MR was written to be a light touch on the rosgo code; however there are some race-conditions/vulnerabilities in the current implementation; namely:
- The 1 second timeout waiting for a read is too long, we should consider reading chunks of the payload and allowing the timeout to extend everytime we do this so that the timeout period is reasonable
- Read operations are race conditions, if a timeout triggers halfway through a write, then we lose a partial buffer and then have to disconnect/reconnect to a publisher in order to synchronize. This recovery mechanism is good; however, the reading could be done better so that we don't have this race condition
