### PR TITLE
Prevent DynamicMessage panics with ill-defined structs

### DIFF
--- a/ros/dynamic_message.go
+++ b/ros/dynamic_message.go
@@ -187,11 +187,17 @@ func (t *DynamicMessageType) Name() string {
 
 // Text returns the full ROS message specification for this message type; required for ros.MessageType.
 func (t *DynamicMessageType) Text() string {
+	if t.spec == nil {
+		return ""
+	}
 	return t.spec.Text
 }
 
 // MD5Sum returns the ROS compatible MD5 sum of the message type; required for ros.MessageType.
 func (t *DynamicMessageType) MD5Sum() string {
+	if t.spec == nil {
+		return ""
+	}
 	return t.spec.MD5Sum
 }
 
@@ -714,6 +720,13 @@ func (m *DynamicMessage) UnmarshalJSON(buf []byte) error {
 
 // Serialize converts a DynamicMessage into a TCPROS bytestream allowing it to be published to other nodes; required for ros.Message.
 func (m *DynamicMessage) Serialize(buf *bytes.Buffer) error {
+	if m.dynamicType.spec == nil {
+		return errors.New("dynamic message type spec is nil")
+	}
+	if m.dynamicType.nested == nil {
+		return errors.New("dynamic message type nested is nil")
+	}
+
 	// THIS METHOD IS BASICALLY AN UNTEMPLATED COPY OF THE TEMPLATE IN LIBGENGO.
 
 	var err error = nil
@@ -1139,6 +1152,13 @@ func (m *DynamicMessage) Serialize(buf *bytes.Buffer) error {
 // Deserialize parses a byte stream into a DynamicMessage, thus reconstructing the fields of a received ROS message; required for ros.Message.
 func (m *DynamicMessage) Deserialize(buf *bytes.Reader) error {
 
+	if m.dynamicType.spec == nil {
+		return errors.New("dynamic message type spec is nil")
+	}
+	if m.dynamicType.nested == nil {
+		return errors.New("dynamic message type nested is nil")
+	}
+
 	// To give more sane results in the event of a decoding issue, we decode into a copy of the data field.
 	var err error = nil
 	tmpData := make(map[string]interface{})
@@ -1284,6 +1304,14 @@ func (m *DynamicMessage) String() string {
 func (t *DynamicMessageType) zeroValueData() (map[string]interface{}, error) {
 	//Create map
 	d := make(map[string]interface{})
+
+	// Function guards to prevent this call from panicking.
+	if t.spec == nil {
+		return d, errors.New("dynamic message type spec is nil")
+	}
+	if t.nested == nil {
+		return d, errors.New("dynamic message type nested is nil")
+	}
 
 	var err error
 

--- a/ros/dynamic_message_test.go
+++ b/ros/dynamic_message_test.go
@@ -447,6 +447,34 @@ func TestDynamicMessage_Deserialize_DynamicArrayMedley(t *testing.T) {
 	}
 }
 
+// Don't panic when the dynamic type is empty - just do nothing instead.
+func TestDynamicMessage_EmptyType_NoPanic(t *testing.T) {
+	testMessageType := DynamicMessageType{}
+
+	msg := testMessageType.NewDynamicMessage()
+
+	if msg.Type().Name() != "" {
+		t.Fatalf("unexpected dynamic message name %s", msg.Type().Name())
+	}
+
+	if msg.Type().MD5Sum() != "" {
+		t.Fatalf("unexpected dynamic message MD5 %s", msg.Type().MD5Sum())
+	}
+
+	if msg.Type().Text() != "" {
+		t.Fatalf("unexpected dynamic message text %s", msg.Type().Text())
+	}
+
+	byteReader := bytes.NewReader([]byte{0x00})
+	if err := msg.Deserialize(byteReader); err == nil {
+		t.Fatalf("expected deserialize error %s", err)
+	}
+	byteBuffer := bytes.NewBuffer(make([]byte, 100))
+	if err := msg.Serialize(byteBuffer); err == nil {
+		t.Fatalf("expected serialize error %s", err)
+	}
+}
+
 // Testing helpers
 
 // Float32Near helper to check that two float32 are within a tolerance.


### PR DESCRIPTION
Closes https://rocosglobal.atlassian.net/browse/ROCOS-2499

Currently, an ill-defined `DynamicMessageType` will result in panic when used to create `DynamicMessage`.

## Changes

* Make `DynamicMessageType` and `DynamicMessage` methods protect against ill-defined structs.