### PR TITLE
RA-470: Dynamic Message - Nested Key fix

### DIFF
--- a/ros/dynamic_message.go
+++ b/ros/dynamic_message.go
@@ -103,31 +103,8 @@ func NewDynamicMessageTypeLiteral(typeName string) (DynamicMessageType, error) {
 // is looked up directly from the existing context.  This 'nested' version of the function is able to be called recursively, where packageName should be the typeName of the
 // parent ROS message; this is used internally for handling complex ROS messages.
 func newDynamicMessageTypeNested(typeName string, packageName string, nested map[string]*DynamicMessageType, nestedChain map[string]struct{}) (*DynamicMessageType, error) {
-
 	// Create an empty message type.
 	m := &DynamicMessageType{}
-
-	if nested == nil {
-		nested = make(map[string]*DynamicMessageType)
-	}
-	if nestedChain == nil {
-		nestedChain = make(map[string]struct{})
-	}
-
-	m.nested = nested
-
-	// The nestedChain is used for recursion detection.
-	if _, ok := nestedChain[typeName]; ok {
-		// DynamicMessageType already created, recursive messages are scary, return error!
-		return nil, errors.New("type already in nested map, message is recursive")
-	}
-
-	// Just return with the messageType if it has been defined already
-	if t, ok := nested[typeName]; ok {
-		return t, nil
-	}
-
-	nestedChain[typeName] = struct{}{}
 
 	// If we haven't created a message context yet, better do that.
 	if context == nil {
@@ -157,6 +134,27 @@ func newDynamicMessageTypeNested(typeName string, packageName string, nested map
 		}
 	}
 
+	// Create nested maps if required.
+	if nested == nil {
+		nested = make(map[string]*DynamicMessageType)
+	}
+	if nestedChain == nil {
+		nestedChain = make(map[string]struct{})
+	}
+
+	// The nestedChain is used for recursion detection.
+	if _, ok := nestedChain[fullname]; ok {
+		// DynamicMessageType already created, recursive messages are scary, return error!
+		return nil, errors.New("type already in nested chain, message is recursive")
+	}
+
+	// Just return with the messageType if it has been defined already
+	if t, ok := nested[fullname]; ok {
+		return t, nil
+	}
+
+	nestedChain[fullname] = struct{}{}
+
 	// Load context for the target message.
 	spec, err := context.LoadMsg(fullname)
 	if err != nil {
@@ -167,22 +165,21 @@ func newDynamicMessageTypeNested(typeName string, packageName string, nested map
 	m.spec = spec
 
 	// Register type in the nested map, this prevents recursion.
-	nested[typeName] = m
+	nested[fullname] = m
 	m.nested = nested
 
 	// Generate the spec for any nested messages.
 	for _, field := range spec.Fields {
 		if field.IsBuiltin == false {
-			newType, err := newDynamicMessageTypeNested(field.Type, field.Package, nested, nestedChain)
+			_, err := newDynamicMessageTypeNested(field.Type, field.Package, nested, nestedChain)
 			if err != nil {
 				return m, err
 			}
-			m.nested[field.Name] = newType
 		}
 	}
 
 	// Unravelling the nested chain, we are done.
-	delete(nestedChain, typeName)
+	delete(nestedChain, fullname)
 
 	// We've successfully made a new message type matching the requested ROS type.
 	return m, nil
@@ -1234,7 +1231,7 @@ func (m *DynamicMessage) Deserialize(buf *bytes.Reader) error {
 				}
 
 				// In this case, it will probably be because the go_type is describing another ROS message type
-				if msgType, ok := m.dynamicType.nested[field.Name]; ok {
+				if msgType, ok := m.dynamicType.nested[field.Package+"/"+field.Type]; ok {
 					tmpData[field.Name], err = d.DecodeMessageArray(buf, size, msgType)
 				} else {
 					err = errors.New("nested message type not known")
@@ -1288,7 +1285,7 @@ func (m *DynamicMessage) Deserialize(buf *bytes.Reader) error {
 
 			} else {
 				// Else it's not a built-in
-				if msgType, ok := m.dynamicType.nested[field.Name]; ok {
+				if msgType, ok := m.dynamicType.nested[field.Package+"/"+field.Type]; ok {
 					tmpData[field.Name], err = d.DecodeMessage(buf, msgType)
 					if err != nil {
 						return errors.Wrap(err, "Field: "+field.Name)
@@ -1376,7 +1373,7 @@ func (t *DynamicMessageType) zeroValueData() (map[string]interface{}, error) {
 
 				// In this case, the go_type is describing another ROS message, so we nest a DynamicMessage.
 				messages := make([]Message, size)
-				if msgType, ok := t.nested[field.Name]; ok {
+				if msgType, ok := t.nested[field.Package+"/"+field.Type]; ok {
 					// Fill out our new messages.
 					for i := 0; i < size; i++ {
 						messages[i] = msgType.NewMessage()
@@ -1424,7 +1421,7 @@ func (t *DynamicMessageType) zeroValueData() (map[string]interface{}, error) {
 				//Else its a ros message type
 			} else {
 				//Create new dynamic message type nested
-				if msgType, ok := t.nested[field.Name]; ok {
+				if msgType, ok := t.nested[field.Package+"/"+field.Type]; ok {
 					d[field.Name] = msgType.NewMessage()
 				} else {
 					return d, errors.Wrap(errors.New("nested message type not known"), "Field: "+field.Name)
@@ -1434,6 +1431,10 @@ func (t *DynamicMessageType) zeroValueData() (map[string]interface{}, error) {
 	}
 	return d, err
 }
+
+// func (t *DynamicMessageType) getNestedTypeFromField(field *libgengo.Field) (*DynamicMessageType, error) {
+// 	if field.Type
+// }
 
 // padArray pads the provided array to the specified length using the default value for the array type.
 func padArray(array interface{}, field libgengo.Field, actualSize, requiredSize uint32) (interface{}, error) {

--- a/ros/dynamic_message_test.go
+++ b/ros/dynamic_message_test.go
@@ -76,11 +76,11 @@ func TestDynamicMessage_DynamicType_Load(t *testing.T) {
 	}
 
 	// Ensure that we have embedded additional DynamicMessageTypes for Point and Quaternion.
-	if len(poseMessageType.nested) != 5 {
-		t.Fatalf("expected 5 nested message types, got %v", poseMessageType.nested)
+	if len(poseMessageType.nested) != 3 {
+		t.Fatalf("expected 3 nested message types, got %v", poseMessageType.nested)
 	}
 
-	if pointType, ok := poseMessageType.nested["position"]; ok {
+	if pointType, ok := poseMessageType.nested["geometry_msgs/Point"]; ok {
 		if pointType.spec.FullName != "geometry_msgs/Point" {
 			t.Fatalf("expected nested Point, got %s", pointType.spec.FullName)
 		}
@@ -88,10 +88,10 @@ func TestDynamicMessage_DynamicType_Load(t *testing.T) {
 			t.Fatalf("expected 3 fields for nested Point type")
 		}
 	} else {
-		t.Fatalf("expected point type under nested[\"position\"]")
+		t.Fatalf("expected point type under nested[\"geometry_msgs/Point\"]")
 	}
 
-	if quatType, ok := poseMessageType.nested["orientation"]; ok {
+	if quatType, ok := poseMessageType.nested["geometry_msgs/Quaternion"]; ok {
 		if quatType.spec.FullName != "geometry_msgs/Quaternion" {
 			t.Fatalf("expected nested Quaternion, got %s", quatType.spec.FullName)
 		}
@@ -99,7 +99,7 @@ func TestDynamicMessage_DynamicType_Load(t *testing.T) {
 			t.Fatalf("expected 4 fields for nested Quaternion type")
 		}
 	} else {
-		t.Fatalf("expected quaternion type under nested[\"orientation\"]")
+		t.Fatalf("expected quaternion type under nested[\"geometry_msgs/Quaternion\"]")
 	}
 
 	// Pose has 7 float64 values, 7 x 8 bytes = 56 bytes.
@@ -120,6 +120,71 @@ func TestDynamicMessage_DynamicType_Load(t *testing.T) {
 	if _, ok = pos.(*DynamicMessage).Data()["x"]; !ok {
 		t.Fatalf("failed to get position.x from pose message")
 	}
+}
+
+func TestDynamicMessage_DynamicType_LoadWithRepeatedFields(t *testing.T) {
+	odomMessageType, err := NewDynamicMessageType("nav_msgs/Odometry")
+
+	if err != nil {
+		t.Skip("test skipped because ROS environment not set up")
+		return
+	}
+
+	if n := len(odomMessageType.spec.Fields); n != 4 {
+		t.Fatalf("got %d fields ,expected 4", n)
+	}
+
+	// Ensure that we have embedded additional DynamicMessageTypes for Point and Quaternion.
+	// if len(poseMessageType.nested) != 5 {
+	// 	t.Fatalf("expected 5 nested message types, got %v", poseMessageType.nested)
+	// }
+
+	// // Pose has 7 float64 values, 7 x 8 bytes = 56 bytes.
+	// slice := make([]byte, 56)
+	// byteReader := bytes.NewReader(slice)
+
+	testMessage := odomMessageType.NewDynamicMessage()
+
+	if testMessage.Data() == nil {
+		t.Fatalf("did not form test message correctly")
+	}
+
+	expectedKeys := map[string]struct{}{
+		"nav_msgs/Odometry":                 {},
+		"std_msgs/Header":                   {},
+		"geometry_msgs/PoseWithCovariance":  {},
+		"geometry_msgs/Pose":                {},
+		"geometry_msgs/Point":               {},
+		"geometry_msgs/Quaternion":          {},
+		"geometry_msgs/TwistWithCovariance": {},
+		"geometry_msgs/Twist":               {},
+		"geometry_msgs/Vector3":             {},
+	}
+
+	for expKey := range expectedKeys {
+		if _, ok := odomMessageType.nested[expKey]; ok == false {
+			t.Fatalf("key '%s' not found in nested type map", expKey)
+		}
+	}
+
+	for nestedKey := range odomMessageType.nested {
+		if _, ok := expectedKeys[nestedKey]; ok == false {
+			t.Fatalf("unexpected key %s found in nested type map", nestedKey)
+		}
+	}
+
+	// if err := testMessage.Deserialize(byteReader); err != nil {
+	// 	t.Fatalf("deserialize pose failed")
+	// }
+
+	// pos, ok := testMessage.Data()["position"]
+	// if !ok {
+	// 	t.Fatalf("failed to get position from pose message")
+	// }
+
+	// if _, ok = pos.(*DynamicMessage).Data()["x"]; !ok {
+	// 	t.Fatalf("failed to get position.x from pose message")
+	// }
 }
 
 func TestDynamicMessage_TypeWithRecursion(t *testing.T) {


### PR DESCRIPTION
Addresses https://rocosglobal.atlassian.net/browse/RA-470

Messages with fields using the same name (ie `{pose: {pose: {...}, covariance: [...]}`) were causing panics.

This was caused by a careless error of using the field's name (ie/ `pose`) rather than the field's full type (ie/ `geometry_msgs/Pose`).

## Changes
* We now store the full type in the nested map (package + type)
* Access to nested types is now provided by `getNestedFromField(field)` to avoid more careless errors

Demonstration of it working on the agent:
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/4222666/105909936-0c6c2000-608d-11eb-8d7d-f12f82f2aa96.png">
