### PR TITLE
RA-473: Unbuffer channels which were causing shutdown hangs

### DIFF
--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -42,7 +42,7 @@ func newDefaultSubscriber(topic string, msgType MessageType, callback interface{
 	sub.msgChan = make(chan messageEvent, 10)
 	sub.pubListChan = make(chan []string, 10)
 	sub.addCallbackChan = make(chan interface{}, 10)
-	sub.shutdownChan = make(chan struct{}, 10)
+	sub.shutdownChan = make(chan struct{})
 	sub.disconnectedChan = make(chan string, 10)
 	sub.uri2pub = make(map[string]string)
 	sub.subscriptionChans = make(map[string]subscriptionChannels)
@@ -90,7 +90,7 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 					addr := protocolParams[1].(string)
 					port := protocolParams[2].(int32)
 					uri := fmt.Sprintf("%s:%d", addr, port)
-					quitChan := make(chan struct{}, 10)
+					quitChan := make(chan struct{})
 					enableMessagesChan := make(chan bool)
 					sub.uri2pub[uri] = pub
 					sub.subscriptionChans[pub] = subscriptionChannels{quit: quitChan, enableMessages: enableMessagesChan}
@@ -143,7 +143,6 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 			// Shutdown subscription goroutine.
 			logger.Debug(sub.topic, " : Receive shutdownChan")
 			for _, closeChan := range sub.subscriptionChans {
-				closeChan.quit <- struct{}{}
 				close(closeChan.quit)
 			}
 			_, err := callRosAPI(masterURI, "unregisterSubscriber", nodeID, sub.topic, nodeAPIURI)

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -130,6 +130,9 @@ func (s *defaultSubscription) connectToPublisher(conn *net.Conn, log *modular.Mo
 
 	// 1. Connnect to tcp.
 	select {
+	case <-s.requestStopChan:
+		logger.WithFields(logrus.Fields{"topic": s.topic, "pubURI": s.pubURI}).Debug("stop requested during connect")
+		return false
 	case <-time.After(time.Duration(3000) * time.Millisecond):
 		logger.WithFields(logrus.Fields{"topic": s.topic, "pubURI": s.pubURI}).Error("failed to connect: timed out")
 		return false

--- a/ros/subscription_test.go
+++ b/ros/subscription_test.go
@@ -387,7 +387,7 @@ func TestSubscription_FlowControl(t *testing.T) {
 	}
 }
 
-// Valid messages are forwarded from the publisher TCP stream by the subscription.
+// Request stop shuts down an active connection.
 func TestSubscription_RequestStop(t *testing.T) {
 	l, conn, subscription := createAndConnectToSubscription(t)
 	defer l.Close()

--- a/ros/subscription_test.go
+++ b/ros/subscription_test.go
@@ -387,6 +387,26 @@ func TestSubscription_FlowControl(t *testing.T) {
 	}
 }
 
+// Valid messages are forwarded from the publisher TCP stream by the subscription.
+func TestSubscription_RequestStop(t *testing.T) {
+	l, conn, subscription := createAndConnectToSubscription(t)
+	defer l.Close()
+	defer conn.Close()
+
+	// Close the stop channel. Expect this to shutdown the subscription.
+	close(subscription.requestStopChan)
+
+	// Check the connection is closed by the subscription.
+	buffer := make([]byte, 1)
+	deadlineDuration := 5 * time.Second                // Subscriptions only check the stop request every second, so our close check needs to be longer.
+	conn.SetDeadline(time.Now().Add(deadlineDuration)) // Deadline stops this running forever if the connection wasn't closed.
+	_, err := conn.Read(buffer)
+
+	if err != io.EOF {
+		t.Fatalf("Expected subscription to close connection, err: %s", err)
+	}
+}
+
 // Private Helper functions.
 
 // Create a test subscription object.


### PR DESCRIPTION
The rosgo `Subscriber` class was not being shutdown correctly because of a buffered channel bug.

The `Subscriber` uses a shutdown pattern which relies on unbuffered channels, however because the channels were buffered, the shutdown request gets consumed by the caller, and the `Subscriber` go routine never gets the signal to shutdown.

This was duplicated in unit tests and then fixed.

Results: (note the /odom log)
![image](https://user-images.githubusercontent.com/4222666/105927995-ff115e80-60a9-11eb-982e-dd38eff7b564.png)

## Changes
* Make `Subscriber` `shutdownChan` unbuffered
* Correct the implementation of the `requestQuitChan` in `Subscription` which was also unnecessarily buffered
  * In this case, we don't want the caller to hang on waiting for these requests to go through, this is achieved by just closing down the  quit channel, and letting the subscription notice it has been closed when it is ready

### Concerns
* There is an awkward corner case where the subscriber could still hang: https://rocosglobal.atlassian.net/browse/ROCOS-2518
  * This is low risk and a bit more involved when solving the issue - so it has been left out of this PR for now. 