### PR TITLE
Rocos 2521: remove subscription pool

### DIFF
--- a/ros/subscription_test.go
+++ b/ros/subscription_test.go
@@ -125,37 +125,6 @@ func TestSubscription_ReadSize_otherError(t *testing.T) {
 
 // Read Raw Data tests.
 
-// Verify pool buffer resizing logic.
-func TestSubscription_ReadRawData_PoolBuffer(t *testing.T) {
-	subscription := getTestSubscription("testUri")
-	if len(subscription.pool) != 0 {
-		t.Fatalf("Expected pool size of 0, but got %d", len(subscription.pool))
-	}
-
-	reader := testReader{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 4, nil}
-
-	// Test 1, read 4 bytes, pool size goes to 4 bytes.
-	reader.n = 4
-	_, _ = subscription.readRawMessage(&reader, 4)
-	if len(subscription.pool) != 4 {
-		t.Fatalf("Expected pool size of 4, but got %d", len(subscription.pool))
-	}
-
-	// Test 2, read 2 bytes, pool size stays at 4 bytes.
-	reader.n = 2
-	_, _ = subscription.readRawMessage(&reader, 2)
-	if len(subscription.pool) != 4 {
-		t.Fatalf("Expected pool size of 4, but got %d", len(subscription.pool))
-	}
-
-	// Test 3, read 10 bytes, pool size goes to 10 bytes.
-	reader.n = 10
-	_, _ = subscription.readRawMessage(&reader, 10)
-	if len(subscription.pool) != 10 {
-		t.Fatalf("Expected pool size of 10, but got %d", len(subscription.pool))
-	}
-}
-
 // Verify basic buffer reading works correctly.
 func TestSubscription_ReadRawData_ReadData(t *testing.T) {
 	subscription := getTestSubscription("testUri")


### PR DESCRIPTION
Closes https://rocosglobal.atlassian.net/browse/ROCOS-2521

The subscription pool was added in https://github.com/team-rocos/rosgo/pull/16 to help reduce the CPU load of the rocos agent.

However, this was an invalid optimization, because it assumed that messages will be decoded before the pool is used again. This is not the case, and results in deserialization errors:
![image](https://user-images.githubusercontent.com/4222666/105957693-75c84f00-60de-11eb-8a15-a85f9c2ece14.png)

## Changes
* This PR removes the subscription pool
* All messages have their memory allocated individually

## Performance

A performance penalty was expected for making this change

Weirdly, that didn't seem to be the case, although it is a little hard to think of a justification why. In both tests below, messages were processed at an interval of 1 second, so the pool bug would not affect performance. 

It is important to note that the spike of this branch, although less frequent, is higher than the spikes in the master branch.

**Performance of rocos agent using rosgo-master**
<img width="1059" alt="cpu-master" src="https://user-images.githubusercontent.com/4222666/105957937-cc358d80-60de-11eb-97a3-eda76fe58c7a.png">

**Performance of rocos agent using this branch**
<img width="1059" alt="cpu-branch" src="https://user-images.githubusercontent.com/4222666/105957947-cf307e00-60de-11eb-8371-dd047e8d7867.png">