### PR TITLE
Rocos 2579 service response errors

### DIFF
--- a/libgengo/context.go
+++ b/libgengo/context.go
@@ -153,8 +153,8 @@ func (ctx *PkgContext) LoadMsgFromString(text string, fullname string) (*MsgSpec
 		return nil, e
 	}
 
-	var fields []Field
-	var constants []Constant
+	fields := make([]Field, 0)
+	constants := make([]Constant, 0)
 	for lineno, origLine := range strings.Split(text, "\n") {
 		cleanLine := stripComment(origLine)
 		if len(cleanLine) == 0 {

--- a/ros/dynamic_service_test.go
+++ b/ros/dynamic_service_test.go
@@ -1,0 +1,51 @@
+package ros
+
+import (
+	"testing"
+)
+
+func TestDynamicService_ServiceType_Load(t *testing.T) {
+	serviceType, err := NewDynamicServiceType("turtlesim/TeleportRelative")
+
+	if err != nil {
+		t.Skipf("test skipped because ROS environment not set up, err: %s", err)
+		return
+	}
+
+	requestType, ok := serviceType.reqType.(*DynamicMessageType)
+
+	if !ok {
+		t.Fatalf("expected request type to be dynamic message type")
+	}
+
+	if requestType.nested == nil {
+		t.Fatalf("request type nested is nil!")
+	}
+
+	if requestType.spec == nil {
+		t.Fatalf("request type spec is nil!")
+	}
+
+	if requestType.spec.Fields == nil {
+		t.Fatalf("request type Fields is nil!")
+	}
+
+	responseType, ok := serviceType.resType.(*DynamicMessageType)
+
+	if !ok {
+		t.Fatalf("expected response type to be dynamic message type")
+	}
+
+	if responseType.nested == nil {
+		t.Fatalf("response type nested is nil!")
+	}
+
+	if responseType.spec == nil {
+		t.Fatalf("response type spec is nil!")
+	}
+
+	if responseType.spec.Fields == nil {
+		t.Fatalf("response type Fields is nil!")
+	}
+
+}

--- a/ros/dynamic_service_test.go
+++ b/ros/dynamic_service_test.go
@@ -12,40 +12,27 @@ func TestDynamicService_ServiceType_Load(t *testing.T) {
 		return
 	}
 
-	requestType, ok := serviceType.reqType.(*DynamicMessageType)
+	checkIfValidDynamicMessageType(t, serviceType.reqType, "request")
+	checkIfValidDynamicMessageType(t, serviceType.resType, "response")
+}
+
+// Helper classes
+func checkIfValidDynamicMessageType(t *testing.T, msgType MessageType, name string) {
+	dynMsgType, ok := msgType.(*DynamicMessageType)
 
 	if !ok {
-		t.Fatalf("expected request type to be dynamic message type")
+		t.Fatalf("expected %s to be dynamic message type", name)
 	}
 
-	if requestType.nested == nil {
-		t.Fatalf("request type nested is nil!")
+	if dynMsgType.nested == nil {
+		t.Fatalf("%s type nested is nil!", name)
 	}
 
-	if requestType.spec == nil {
-		t.Fatalf("request type spec is nil!")
+	if dynMsgType.spec == nil {
+		t.Fatalf("%s type spec is nil!", name)
 	}
 
-	if requestType.spec.Fields == nil {
-		t.Fatalf("request type Fields is nil!")
+	if dynMsgType.spec.Fields == nil {
+		t.Fatalf("%s type Fields is nil!", name)
 	}
-
-	responseType, ok := serviceType.resType.(*DynamicMessageType)
-
-	if !ok {
-		t.Fatalf("expected response type to be dynamic message type")
-	}
-
-	if responseType.nested == nil {
-		t.Fatalf("response type nested is nil!")
-	}
-
-	if responseType.spec == nil {
-		t.Fatalf("response type spec is nil!")
-	}
-
-	if responseType.spec.Fields == nil {
-		t.Fatalf("response type Fields is nil!")
-	}
-
 }

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -14,6 +14,12 @@ import (
 	modular "github.com/edwinhayes/logrus-modular"
 )
 
+const headerReadTimeout time.Duration = 1000 * time.Millisecond
+const okReplyTimeout time.Duration = 1000 * time.Millisecond
+const responseTimeout time.Duration = 5000 * time.Millisecond
+const responseBaseTimeout time.Duration = 1000 * time.Millisecond
+const responseByteMultiplier time.Duration = time.Millisecond
+
 type defaultServiceClient struct {
 	logger    *modular.ModuleLogger
 	service   string
@@ -74,13 +80,12 @@ func (c *defaultServiceClient) doServiceRequest(srv Service, serviceURI string) 
 	for _, h := range headers {
 		logger.Debugf("  `%s` = `%s`", h.key, h.value)
 	}
-	conn.SetDeadline(time.Now().Add(50 * time.Millisecond))
 	if err := writeConnectionHeader(headers, conn); err != nil {
 		return err
 	}
 
 	// 2. Read reponse header
-	conn.SetDeadline(time.Now().Add(50 * time.Millisecond))
+	conn.SetReadDeadline(time.Now().Add(headerReadTimeout))
 	resHeaders, err := readConnectionHeader(conn)
 	if err != nil {
 		return err
@@ -105,30 +110,29 @@ func (c *defaultServiceClient) doServiceRequest(srv Service, serviceURI string) 
 	}
 	reqMsg := buf.Bytes()
 	size := uint32(len(reqMsg))
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
 	if err := binary.Write(conn, binary.LittleEndian, size); err != nil {
 		return err
 	}
 	logger.Debugf("sent request, length: %d", size)
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
 	if _, err := conn.Write(reqMsg); err != nil {
 		return err
 	}
 
 	// 4. Read OK byte
 	var ok byte
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetReadDeadline(time.Now().Add(okReplyTimeout))
 	if err := binary.Read(conn, binary.LittleEndian, &ok); err != nil {
 		return err
 	}
 	if ok == 0 {
 		var size uint32
-		conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+		conn.SetDeadline(time.Now().Add(responseTimeout))
 		if err := binary.Read(conn, binary.LittleEndian, &size); err != nil {
 			return err
 		}
 		errMsg := make([]byte, int(size))
-		conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+		conn.SetDeadline(time.Now().Add(responseBaseTimeout).Add(responseByteMultiplier * time.Duration(size)))
+
 		if _, err := io.ReadFull(conn, errMsg); err != nil {
 			return err
 		}
@@ -136,13 +140,14 @@ func (c *defaultServiceClient) doServiceRequest(srv Service, serviceURI string) 
 	}
 
 	// 5. Receive response
-	conn.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetDeadline(time.Now().Add(responseTimeout))
 	var msgSize uint32
 	if err := binary.Read(conn, binary.LittleEndian, &msgSize); err != nil {
 		return err
 	}
 	logger.Debugf("Message Size:  %d", msgSize)
 	resBuffer := make([]byte, int(msgSize))
+	conn.SetDeadline(time.Now().Add(responseBaseTimeout).Add(responseByteMultiplier * time.Duration(msgSize)))
 	if _, err = io.ReadFull(conn, resBuffer); err != nil {
 		return err
 	}

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -33,7 +33,6 @@ func newDefaultServiceClient(log *modular.ModuleLogger, nodeID string, masterURI
 }
 
 func (c *defaultServiceClient) Call(srv Service) error {
-	logger := *c.logger
 
 	result, err := callRosAPI(c.masterURI, "lookupService", c.nodeID, c.service)
 	if err != nil {
@@ -50,8 +49,15 @@ func (c *defaultServiceClient) Call(srv Service) error {
 		return err
 	}
 
+	return c.doServiceRequest(srv, serviceURL.Host)
+}
+
+func (c *defaultServiceClient) doServiceRequest(srv Service, serviceURI string) error {
+	logger := *c.logger
+
 	var conn net.Conn
-	conn, err = net.Dial("tcp", serviceURL.Host)
+	var err error
+	conn, err = net.Dial("tcp", serviceURI)
 	if err != nil {
 		return err
 	}

--- a/ros/service_client_test.go
+++ b/ros/service_client_test.go
@@ -1,0 +1,348 @@
+package ros
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	modular "github.com/edwinhayes/logrus-modular"
+	"github.com/sirupsen/logrus"
+)
+
+// Fake Service types for testing.
+
+// Set up testRequestMessage fakes.
+type testRequestMessageType struct{}
+type testRequestMessage struct {
+	err error
+}
+
+// Ensure we satisfy the required interfaces.
+var _ MessageType = testRequestMessageType{}
+var _ Message = testRequestMessage{}
+
+func (t testRequestMessageType) Text() string {
+	return "test_request_type"
+}
+
+func (t testRequestMessageType) MD5Sum() string {
+	return "0123456789abcdeffedcba9876543210"
+}
+
+func (t testRequestMessageType) Name() string {
+	return "test_request"
+}
+
+func (t testRequestMessageType) NewMessage() Message {
+	return &testRequestMessage{}
+}
+
+func (m testRequestMessage) Type() MessageType {
+	return &testRequestMessageType{}
+}
+
+func (m testRequestMessage) Serialize(buf *bytes.Buffer) error {
+	buf.WriteString("Request")
+	return m.err
+}
+
+func (m testRequestMessage) Deserialize(buf *bytes.Reader) error {
+	return m.err
+}
+
+// Set up testResponseMessage fakes.
+type testResponseMessageType struct{}
+type testResponseMessage struct {
+	err error
+}
+
+// Ensure we satisfy the required interfaces.
+var _ MessageType = testResponseMessageType{}
+var _ Message = testResponseMessage{}
+
+func (t testResponseMessageType) Text() string {
+	return "test_response_type"
+}
+
+func (t testResponseMessageType) MD5Sum() string {
+	return "0123456789abcdeffedcba9876543210"
+}
+
+func (t testResponseMessageType) Name() string {
+	return "test_response"
+}
+
+func (t testResponseMessageType) NewMessage() Message {
+	return &testResponseMessage{}
+}
+
+func (m testResponseMessage) Type() MessageType {
+	return &testResponseMessageType{}
+}
+
+func (m testResponseMessage) Serialize(buf *bytes.Buffer) error {
+	buf.WriteString("Response")
+	return m.err
+}
+
+func (m testResponseMessage) Deserialize(buf *bytes.Reader) error {
+	return m.err
+}
+
+type testServiceType struct{}
+type testService struct {
+	requestErr  error // Injects an error into the serialize/deserialize methods of its request messages.
+	responseErr error // Injects an error into the serialize/deserialize methods of its response messages.
+}
+
+// Ensure we satisfy the required interfaces.
+var _ ServiceType = testServiceType{}
+var _ Service = testService{}
+
+func (t testServiceType) MD5Sum() string {
+	return "0123456789abcdeffedcba9876543210"
+}
+
+func (t testServiceType) Name() string {
+	return "test_service"
+}
+
+func (t testServiceType) RequestType() MessageType {
+	return &testRequestMessageType{}
+}
+
+func (t testServiceType) ResponseType() MessageType {
+	return &testResponseMessageType{}
+}
+
+func (t testServiceType) NewService() Service {
+	return &testService{}
+}
+
+func (s testService) ReqMessage() Message {
+	return &testRequestMessage{s.requestErr}
+}
+
+func (s testService) ResMessage() Message {
+	return &testResponseMessage{s.responseErr}
+}
+
+// Tests
+
+func TestServiceClient_SuccessfulServiceExchange(t *testing.T) {
+	l, conn, client, result := setupServiceServerAndClient(t)
+	defer l.Close()
+	defer conn.Close()
+
+	doServiceServerHeaderExchange(t, conn, client)
+	doReceiveRequest(t, conn)
+	doSendOk(t, conn, true)
+	doSendResponse(t, conn)
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("took too long for client to stop")
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("expected successful request/response, got error %s", err)
+		}
+	}
+}
+
+func TestServiceClient_HangUpError_HeaderExchange(t *testing.T) {
+	l, conn, _, result := setupServiceServerAndClient(t)
+
+	conn.Close()
+	l.Close()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("took too long to shutdown test client")
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected error from early hang up, got no error")
+		}
+	}
+}
+
+func TestServiceClient_HangUpError_Ok(t *testing.T) {
+	l, conn, client, result := setupServiceServerAndClient(t)
+	defer l.Close()
+	defer conn.Close()
+
+	doServiceServerHeaderExchange(t, conn, client)
+	doReceiveRequest(t, conn)
+
+	conn.Close()
+	l.Close()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("took too long to shutdown test client")
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected error from early hang up, got no error")
+		}
+	}
+}
+
+func TestServiceClient_HangUpError_Response(t *testing.T) {
+	l, conn, client, result := setupServiceServerAndClient(t)
+	defer l.Close()
+	defer conn.Close()
+
+	doServiceServerHeaderExchange(t, conn, client)
+	doReceiveRequest(t, conn)
+	doSendOk(t, conn, true)
+
+	conn.Close()
+	l.Close()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("took too long to shutdown test client")
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected error from early hang up, got no error")
+		}
+	}
+}
+
+func TestServiceClient_NotOkError(t *testing.T) {
+	l, conn, client, result := setupServiceServerAndClient(t)
+	defer l.Close()
+	defer conn.Close()
+
+	doServiceServerHeaderExchange(t, conn, client)
+	doReceiveRequest(t, conn)
+	doSendOk(t, conn, false)
+	doSendResponse(t, conn)
+
+	conn.Close()
+	l.Close()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("took too long to shutdown test client")
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected error from early hang up, got no error")
+		}
+	}
+}
+
+// Test helper functions.
+
+func doReceiveRequest(t *testing.T, conn net.Conn) {
+	// Receive a request.
+	var size uint32
+	if err := binary.Read(conn, binary.LittleEndian, &size); err != nil {
+		t.Fatalf("failed to read request size, %s", err)
+	}
+
+	if size != 7 {
+		t.Fatalf("expected size 7, got %d", size)
+	}
+
+	buffer := make([]byte, 7) // Expect `Request`.
+	n, err := conn.Read(buffer)
+
+	if err != nil {
+		t.Fatalf("received error instead of request: %s", err)
+	}
+	if n != 7 {
+		t.Fatalf("expected to read 7 bytes, got %d", n)
+	}
+	if string(buffer) != "Request" {
+		t.Fatalf("request serialized to unexpected bytes, expected `Request` got %s", string(buffer[4:]))
+	}
+}
+func doSendOk(t *testing.T, conn net.Conn, isOk bool) {
+	var ok uint8
+	if isOk {
+		ok = 1
+	} else {
+		ok = 0
+	}
+
+	// Reply with Ok byte.
+	if err := binary.Write(conn, binary.LittleEndian, &ok); err != nil {
+		t.Fatalf("failed to write response size, %s", err)
+	}
+}
+
+func doSendResponse(t *testing.T, conn net.Conn) {
+	size := uint32(8)
+	buffer := []byte("response")
+
+	// Send a response.
+	if err := binary.Write(conn, binary.LittleEndian, &size); err != nil {
+		t.Fatalf("failed to write response size, %s", err)
+	}
+	n, err := conn.Write(buffer)
+	if err != nil {
+		t.Fatalf("failed to write response, error: %s", err)
+	}
+	if n != 8 {
+		t.Fatalf("expected to write 8 bytes, got %d", n)
+	}
+}
+
+// setupServiceServer establishes all init values
+func setupServiceServerAndClient(t *testing.T) (net.Listener, net.Conn, *defaultServiceClient, chan error) {
+	rootLogger := modular.NewRootLogger(logrus.New())
+
+	logger := rootLogger.GetModuleLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serviceURI := l.Addr().String()
+
+	client := &defaultServiceClient{
+		logger:    &logger,
+		service:   "/test/service",
+		srvType:   testServiceType{},
+		masterURI: "",
+		nodeID:    "testNode",
+	}
+
+	result := make(chan error)
+	go func() {
+		err := client.doServiceRequest(testService{}, serviceURI)
+		result <- err
+	}()
+
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return l, conn, client, result
+}
+
+// doHeaderExchange emulates the header exchange as a service server. Puts the client in a state where it is ready to send a request.
+func doServiceServerHeaderExchange(t *testing.T, conn net.Conn, client *defaultServiceClient) {
+	_, err := readConnectionHeader(conn)
+
+	if err != nil {
+		t.Fatal("Failed to read header:", err)
+	}
+
+	replyHeader := []header{
+		{"service", client.service},
+		{"md5sum", client.srvType.MD5Sum()},
+		{"type", client.srvType.Name()},
+		{"callerid", "testServer"},
+	}
+
+	err = writeConnectionHeader(replyHeader, conn)
+	if err != nil {
+		t.Fatalf("Failed to write header: %s", replyHeader)
+	}
+}


### PR DESCRIPTION
Closes https://rocosglobal.atlassian.net/browse/ROCOS-2579

This PR addresses two issues:
* Services causing an IO timeout
* DynamicMessages with nil fields failing to parse JSON
  * This occurs in Services which include an empty response packet (such as `turtlesim/TeleportRelative`)

## Changes
* Add thorough testing to `service_client`
* Add less-magic timeouts to `service_client` to address the IO timeout
* Force libgengo to provide an empty slice of fields rather than a nil field for empty messages

Results:
<img width="808" alt="image" src="https://user-images.githubusercontent.com/4222666/107481069-7256bc80-6be2-11eb-85a9-7b28fa86de55.png">


Additional ticket has been added for later to address making service calls cancellable: https://rocosglobal.atlassian.net/browse/ROCOS-2580