### PR TITLE
Fix RA-472: Action goals not detected

### DIFF
--- a/ros/byte_decoder_le.go
+++ b/ros/byte_decoder_le.go
@@ -51,6 +51,10 @@ func (d LEByteDecoder) DecodeUint8Array(buf *bytes.Reader, size int) ([]uint8, e
 	var err error
 	var n int
 	slice := make([]uint8, size)
+	if size == 0 {
+		// Early return to avoid potentail EOF error.
+		return slice, nil
+	}
 	n, err = buf.Read(slice)
 	if n != size || err != nil {
 		return slice, errors.New("Did not read entire uint8 buffer")

--- a/ros/dynamic_action.go
+++ b/ros/dynamic_action.go
@@ -105,19 +105,25 @@ func newDynamicActionTypeNested(typeName string, packageName string) (*DynamicAc
 	m.text = spec.Text
 
 	// Create Dynamic Goal Type
-	goalType := &DynamicActionGoalType{}
-	goalType.spec = spec.ActionGoal
-	m.goalType = goalType
+	goalType, err := NewDynamicMessageTypeFromSpec(spec.ActionGoal)
+	if err != nil {
+		return nil, err
+	}
+	m.goalType = &DynamicActionGoalType{*goalType}
 
 	// Create Dynamic Feedback Type
-	feedbackType := &DynamicActionFeedbackType{}
-	feedbackType.spec = spec.ActionFeedback
-	m.feedbackType = feedbackType
+	feedbackType, err := NewDynamicMessageTypeFromSpec(spec.ActionFeedback)
+	if err != nil {
+		return nil, err
+	}
+	m.feedbackType = &DynamicActionFeedbackType{*feedbackType}
 
 	// Create Dynamic Result Type
-	resultType := &DynamicActionResultType{}
-	resultType.spec = spec.ActionResult
-	m.resultType = resultType
+	resultType, err := NewDynamicMessageTypeFromSpec(spec.ActionResult)
+	if err != nil {
+		return nil, err
+	}
+	m.resultType = &DynamicActionResultType{*resultType}
 
 	// We've successfully made a new service type matching the requested ROS type.
 	return m, nil

--- a/ros/dynamic_action.go
+++ b/ros/dynamic_action.go
@@ -176,21 +176,29 @@ func (a *DynamicActionStatusArrayType) NewStatusArrayMessage() ActionStatusArray
 func (a *DynamicActionStatusArrayType) NewStatusArrayFromInterface(statusArr interface{}) ActionStatusArray {
 	statusArray := statusArr.(*DynamicMessage)
 	status := a.NewStatusArrayMessage().(*DynamicActionStatusArray)
-	statusMsgs := statusArray.Data()["status_list"].([]Message)
 	statusList := make([]ActionStatus, 0)
-	for _, statusMsg := range statusMsgs {
-		buildStatus := NewActionStatusType().NewStatusMessage()
-		goalidMsg := statusMsg.(*DynamicMessage).Data()["goal_id"].(*DynamicMessage)
-		goalID := NewActionGoalIDType().NewGoalIDMessage().(*DynamicActionGoalID)
-		goalID.SetID(goalidMsg.Data()["id"].(string))
-		goalID.SetStamp(goalidMsg.Data()["stamp"].(Time))
-		buildStatus.SetGoalID(goalID)
-		buildStatus.SetStatus(statusMsg.(*DynamicMessage).Data()["status"].(uint8))
-		buildStatus.SetStatusText(statusMsg.(*DynamicMessage).Data()["text"].(string))
-		statusList = append(statusList, buildStatus)
+
+	if statusMsgsInterface, ok := statusArray.Data()["status_list"]; ok {
+		if statusMsgs, ok := statusMsgsInterface.([]Message); ok {
+			for _, statusMsg := range statusMsgs {
+				buildStatus := NewActionStatusType().NewStatusMessage()
+				goalidMsg := statusMsg.(*DynamicMessage).Data()["goal_id"].(*DynamicMessage)
+				goalID := NewActionGoalIDType().NewGoalIDMessage().(*DynamicActionGoalID)
+				goalID.SetID(goalidMsg.Data()["id"].(string))
+				goalID.SetStamp(goalidMsg.Data()["stamp"].(Time))
+				buildStatus.SetGoalID(goalID)
+				buildStatus.SetStatus(statusMsg.(*DynamicMessage).Data()["status"].(uint8))
+				buildStatus.SetStatusText(statusMsg.(*DynamicMessage).Data()["text"].(string))
+				statusList = append(statusList, buildStatus)
+			}
+		}
 	}
 	status.SetStatusArray(statusList)
-	status.SetHeader(statusArray.Data()["header"].(Message))
+	if statusHeaderInterface, ok := statusArray.Data()["header"]; ok {
+		if statusHeader, ok := statusHeaderInterface.(Message); ok {
+			status.SetHeader(statusHeader)
+		}
+	}
 	return status
 }
 

--- a/ros/dynamic_message.go
+++ b/ros/dynamic_message.go
@@ -95,6 +95,7 @@ func NewDynamicMessageTypeLiteral(typeName string) (DynamicMessageType, error) {
 	return *t, err
 }
 
+// TODO Update description
 // NewDynamicMessageType generates a DynamicMessageType corresponding to the specified typeName from the available ROS message definitions; typeName should be a fully-qualified
 // ROS message type name.  The first time the function is run, a message 'context' is created by searching through the available ROS message definitions, then the ROS message to
 // be used for the definition is looked up by name.  On subsequent calls, the ROS message type is looked up directly from the existing context.
@@ -195,6 +196,7 @@ func newDynamicMessageTypeNested(typeName string, packageName string, nested map
 	return m, err
 }
 
+// TODO Add description
 func (m *DynamicMessageType) populateFromSpec(spec *libgengo.MsgSpec, nested map[string]*DynamicMessageType, nestedChain map[string]struct{}) error {
 	// Create nested maps if required.
 	if nested == nil || nestedChain == nil {

--- a/ros/dynamic_message.go
+++ b/ros/dynamic_message.go
@@ -95,10 +95,8 @@ func NewDynamicMessageTypeLiteral(typeName string) (DynamicMessageType, error) {
 	return *t, err
 }
 
-// TODO Update description
-// NewDynamicMessageType generates a DynamicMessageType corresponding to the specified typeName from the available ROS message definitions; typeName should be a fully-qualified
-// ROS message type name.  The first time the function is run, a message 'context' is created by searching through the available ROS message definitions, then the ROS message to
-// be used for the definition is looked up by name.  On subsequent calls, the ROS message type is looked up directly from the existing context.
+// NewDynamicMessageTypeFromSpec creates a DynamicMessageType using a preloaded message specification.
+// When loading a service or action, multiple message specs are loaded at once, so `NewDynamicMessageType` is not applicable.
 func NewDynamicMessageTypeFromSpec(spec *libgengo.MsgSpec) (*DynamicMessageType, error) {
 	if spec == nil {
 		return nil, errors.New("spec is empty")
@@ -115,7 +113,7 @@ func NewDynamicMessageTypeFromSpec(spec *libgengo.MsgSpec) (*DynamicMessageType,
 	nestedChain[spec.FullName] = struct{}{}
 
 	// Populate the DynamicMessageType data from spec.
-	err := t.populateFromSpec(spec, t.nested, nestedChain)
+	err := t.populateFromSpec(spec, nestedChain)
 
 	return t, err
 }
@@ -126,14 +124,14 @@ func NewDynamicMessageTypeFromSpec(spec *libgengo.MsgSpec) (*DynamicMessageType,
 // parent ROS message; this is used internally for handling complex ROS messages.
 func newDynamicMessageTypeNested(typeName string, packageName string, nested map[string]*DynamicMessageType, nestedChain map[string]struct{}) (*DynamicMessageType, error) {
 	// Create an empty message type.
-	m := &DynamicMessageType{}
+	t := &DynamicMessageType{}
 
 	// If we haven't created a message context yet, better do that.
 	if context == nil {
 		// Create context for our ROS install.
 		c, err := libgengo.NewPkgContext(strings.Split(GetRuntimePackagePath(), ":"))
 		if err != nil {
-			return m, err
+			return t, err
 		}
 		context = c
 	}
@@ -171,8 +169,8 @@ func newDynamicMessageTypeNested(typeName string, packageName string, nested map
 	}
 
 	// Just return with the messageType if it has been defined already
-	if t, ok := nested[fullname]; ok {
-		return t, nil
+	if tRegistered, ok := nested[fullname]; ok {
+		return tRegistered, nil
 	}
 
 	nestedChain[fullname] = struct{}{}
@@ -180,39 +178,39 @@ func newDynamicMessageTypeNested(typeName string, packageName string, nested map
 	// Load context for the target message.
 	spec, err := context.LoadMsg(fullname)
 	if err != nil {
-		return m, err
+		return t, err
 	}
 
-	nested[spec.FullName] = m
-	m.nested = nested
+	nested[spec.FullName] = t
+	t.nested = nested
 
 	// Unravelling the nested chain, we are done.
-	err = m.populateFromSpec(spec, nested, nestedChain)
+	err = t.populateFromSpec(spec, nestedChain)
 
 	// Unravelling the nested chain, we are done.
 	delete(nestedChain, fullname)
 
 	// We've successfully made a new message type matching the requested ROS type.
-	return m, err
+	return t, err
 }
 
-// TODO Add description
-func (m *DynamicMessageType) populateFromSpec(spec *libgengo.MsgSpec, nested map[string]*DynamicMessageType, nestedChain map[string]struct{}) error {
+// populateFromSpec takes a message spec and fills a DynamicMessageType fields. Expects that we have a valid nested chain map.
+func (t *DynamicMessageType) populateFromSpec(spec *libgengo.MsgSpec, nestedChain map[string]struct{}) error {
 	// Create nested maps if required.
-	if nested == nil || nestedChain == nil {
+	if t.nested == nil || nestedChain == nil {
 		return errors.New("nested maps were not populated")
 	}
 
 	// Now we know all about the message!
-	m.spec = spec
+	t.spec = spec
 
 	// Just come up with a dumb guess for preallocation. This will get set better on the first call.
-	m.jsonPrealloc = 3 + len(spec.Fields)*3
+	t.jsonPrealloc = 3 + len(spec.Fields)*3
 
 	// Generate the spec for any nested messages.
 	for _, field := range spec.Fields {
 		if field.IsBuiltin == false {
-			_, err := newDynamicMessageTypeNested(field.Type, field.Package, nested, nestedChain)
+			_, err := newDynamicMessageTypeNested(field.Type, field.Package, t.nested, nestedChain)
 			if err != nil {
 				return err
 			}

--- a/ros/dynamic_message_json.go
+++ b/ros/dynamic_message_json.go
@@ -357,9 +357,9 @@ func marshalFloat(f float64, buf *[]byte, bits int) {
 }
 
 func marshalSecNSec(sec uint64, nsec uint64, buf *[]byte) {
-	*buf = append(*buf, []byte("{\"Sec\":")...)
+	*buf = append(*buf, []byte("{\"sec\":")...)
 	*buf = strconv.AppendUint(*buf, sec, 10)
-	*buf = append(*buf, []byte(",\"NSec\":")...)
+	*buf = append(*buf, []byte(",\"nsec\":")...)
 	*buf = strconv.AppendUint(*buf, nsec, 10)
 	*buf = append(*buf, byte('}'))
 }
@@ -692,16 +692,16 @@ func unmarshalSecNSecObject(marshalled []byte) (sec uint32, nsec uint32, err err
 	hasSec := false
 	hasNSec := false
 
-	// Expects the object to be {"Sec":n,"NSec":n} (although, order doesn't matter).
+	// Expects the object to be {"sec":n,"nsec":n} (although, order doesn't matter).
 	err = jsonparser.ObjectEach(marshalled, func(k []byte, v []byte, dataType jsonparser.ValueType, offset int) error {
 		var err error
 		switch string(k) {
-		case "Sec":
+		case "sec":
 			tempSec, err = jsonparser.ParseInt(v)
 			if err == nil {
 				hasSec = true
 			}
-		case "NSec":
+		case "nsec":
 			tempNSec, err = jsonparser.ParseInt(v)
 			if err == nil {
 				hasNSec = true

--- a/ros/dynamic_message_json_test.go
+++ b/ros/dynamic_message_json_test.go
@@ -145,12 +145,12 @@ func TestDynamicMessage_JSON_primitives(t *testing.T) {
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", false, 0)},
 			data:       map[string]interface{}{"t": NewTime(0xfeedf00d, 0x1337beef)},
-			marshalled: `{"t":{"Sec":4277006349,"NSec":322420463}}`,
+			marshalled: `{"t":{"sec":4277006349,"nsec":322420463}}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", false, 0)},
 			data:       map[string]interface{}{"d": NewDuration(0x40302010, 0x00706050)},
-			marshalled: `{"d":{"Sec":1076895760,"NSec":7364688}}`,
+			marshalled: `{"d":{"sec":1076895760,"nsec":7364688}}`,
 		},
 		// Fixed and Dynamic arrays.
 		// - Unsigned integers.
@@ -282,23 +282,23 @@ func TestDynamicMessage_JSON_primitives(t *testing.T) {
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", true, 2)},
 			data:       map[string]interface{}{"t": []Time{NewTime(0xfeedf00d, 0x1337beef), NewTime(0x1337beef, 0x00706050)}},
-			marshalled: `{"t":[{"Sec":4277006349,"NSec":322420463},{"Sec":322420463,"NSec":7364688}]}`,
+			marshalled: `{"t":[{"sec":4277006349,"nsec":322420463},{"sec":322420463,"nsec":7364688}]}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", true, -1)}, // Dynamic.
 			data:       map[string]interface{}{"t": []Time{NewTime(0xfeedf00d, 0x1337beef), NewTime(0x1337beef, 0x00706050)}},
-			marshalled: `{"t":[{"Sec":4277006349,"NSec":322420463},{"Sec":322420463,"NSec":7364688}]}`,
+			marshalled: `{"t":[{"sec":4277006349,"nsec":322420463},{"sec":322420463,"nsec":7364688}]}`,
 		},
 		// - Duration.
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, 2)},
 			data:       map[string]interface{}{"d": []Duration{NewDuration(0xfeedf00d, 0x1337beef), NewDuration(0x1337beef, 0x00706050)}},
-			marshalled: `{"d":[{"Sec":4277006349,"NSec":322420463},{"Sec":322420463,"NSec":7364688}]}`,
+			marshalled: `{"d":[{"sec":4277006349,"nsec":322420463},{"sec":322420463,"nsec":7364688}]}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, -1)}, // Dynamic.
 			data:       map[string]interface{}{"d": []Duration{NewDuration(0xfeedf00d, 0x1337beef), NewDuration(0x1337beef, 0x00706050)}},
-			marshalled: `{"d":[{"Sec":4277006349,"NSec":322420463},{"Sec":322420463,"NSec":7364688}]}`,
+			marshalled: `{"d":[{"sec":4277006349,"nsec":322420463},{"sec":322420463,"nsec":7364688}]}`,
 		},
 	}
 
@@ -968,7 +968,7 @@ func TestDynamicMessage_JSONUnmarshal_errors(t *testing.T) {
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "uint64", "u64", false, 0)},
-			marshalled: `{"u64":{"Sec":0,"NSec":1}}`,
+			marshalled: `{"u64":{"sec":0,"nsec":1}}`,
 		},
 		// - Signed integers.
 		{
@@ -1081,11 +1081,11 @@ func TestDynamicMessage_JSONUnmarshal_errors(t *testing.T) {
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", false, 0)},
-			marshalled: `{"t":{"NSec":1}}`,
+			marshalled: `{"t":{"nsec":1}}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", false, 0)},
-			marshalled: `{"t":{"Sec":1}}`,
+			marshalled: `{"t":{"sec":1}}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", false, 0)},
@@ -1093,11 +1093,11 @@ func TestDynamicMessage_JSONUnmarshal_errors(t *testing.T) {
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", false, 0)},
-			marshalled: `{"d":{"Sec":true,"NSec":true}}`,
+			marshalled: `{"d":{"sec":true,"nsec":true}}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", false, 0)},
-			marshalled: `{"d":[{"Sec":"","NSec":""}]}`,
+			marshalled: `{"d":[{"sec":"","nsec":""}]}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", false, 0)},
@@ -1248,37 +1248,37 @@ func TestDynamicMessage_JSONUnmarshal_errors(t *testing.T) {
 		// - Time.
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", true, 2)},
-			marshalled: `{"t":[{"Sec":322420463,"NSec":7364688}]}`, // Wrong length.
+			marshalled: `{"t":[{"sec":322420463,"nsec":7364688}]}`, // Wrong length.
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", true, 1)},
-			marshalled: `{"t":{"Sec":322420463,"NSec":7364688}}`,
+			marshalled: `{"t":{"sec":322420463,"nsec":7364688}}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "time", "t", true, 1)},
-			marshalled: `{"t":[{"Sec":"zero","NSec":7364688}]}`,
+			marshalled: `{"t":[{"sec":"zero","nsec":7364688}]}`,
 		},
 		// - Duration.
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, 2)},
-			marshalled: `{"d":[{"Sec":322420463,"NSec":7364688}]}`, // Wrong length.
+			marshalled: `{"d":[{"sec":322420463,"nsec":7364688}]}`, // Wrong length.
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, 2)},
-			marshalled: `{"d":{"Sec":322420463,"NSec":7364688}}`,
+			marshalled: `{"d":{"sec":322420463,"nsec":7364688}}`,
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, 2)},
-			marshalled: `{"d":[{"Sec":"zero","NSec":7364688}]}`,
+			marshalled: `{"d":[{"sec":"zero","nsec":7364688}]}`,
 		},
 		// Other errors.
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, 1)},
-			marshalled: `{"t":[{"Sec":0,"NSec":7364688}]}`, // Key not found.
+			marshalled: `{"t":[{"sec":0,"nsec":7364688}]}`, // Key not found.
 		},
 		{
 			fields:     []gengo.Field{*gengo.NewField("Testing", "duration", "d", true, 1)},
-			marshalled: `{"d":[{"Sec":0,"NSec":7364688}],"t":[{"Sec":0,"NSec":7364688}]}`, // Unknown key.
+			marshalled: `{"d":[{"sec":0,"nsec":7364688}],"t":[{"sec":0,"nsec":7364688}]}`, // Unknown key.
 		},
 	}
 

--- a/ros/dynamic_message_json_test.go
+++ b/ros/dynamic_message_json_test.go
@@ -733,12 +733,14 @@ func TestDynamicMessage_marshalJSON_arrayOfNestedMessages(t *testing.T) {
 		*gengo.NewField("test", "uint8", "val", false, 0),
 	}
 	msgSpec := generateTestSpec(fields)
+	msgSpec.FullName = "test/x0Message"
 	context.RegisterMsg("test/x0Message", msgSpec)
 
 	fields = []gengo.Field{
 		*gengo.NewField("test", "x0Message", "x", true, 2),
 	}
 	msgSpec = generateTestSpec(fields)
+	msgSpec.FullName = "test/z0Message"
 	context.RegisterMsg("test/z0Message", msgSpec)
 
 	testMessageType, err := NewDynamicMessageType("test/z0Message")

--- a/ros/dynamic_message_test.go
+++ b/ros/dynamic_message_test.go
@@ -192,6 +192,7 @@ func TestDynamicMessage_TypeWithRecursion(t *testing.T) {
 		*gengo.NewField("test", "recursiveMessage", "x", true, -1),
 	}
 	msgSpec := generateTestSpec(fields)
+	msgSpec.FullName = "recursiveMessage"
 	context.RegisterMsg("recursiveMessage", msgSpec)
 
 	_, err = NewDynamicMessageType("recursiveMessage") // If this isn't handled correctly, we get stack overflow.
@@ -214,18 +215,21 @@ func TestDynamicMessage_TypeWithBuriedRecursion(t *testing.T) {
 		*gengo.NewField("test", "yMessage", "y", true, -1),
 	}
 	msgSpec := generateTestSpec(fields)
+	msgSpec.FullName = "xMessage"
 	context.RegisterMsg("xMessage", msgSpec)
 
 	fields = []gengo.Field{
 		*gengo.NewField("test", "zMessage", "z", true, -1),
 	}
 	msgSpec = generateTestSpec(fields)
+	msgSpec.FullName = "yMessage"
 	context.RegisterMsg("yMessage", msgSpec)
 
 	fields = []gengo.Field{
 		*gengo.NewField("test", "xMessage", "x", true, -1),
 	}
 	msgSpec = generateTestSpec(fields)
+	msgSpec.FullName = "zMessage"
 	context.RegisterMsg("zMessage", msgSpec)
 
 	_, err = NewDynamicMessageType("xMessage") // If this isn't handled correctly, we get stack overflow.
@@ -248,6 +252,7 @@ func TestDynamicMessage_RepeatedTypes_ButNoRecursion(t *testing.T) {
 		*gengo.NewField("test", "uint8", "val", true, -1),
 	}
 	msgSpec := generateTestSpec(fields)
+	msgSpec.FullName = "xMessage"
 	context.RegisterMsg("xMessage", msgSpec)
 
 	fields = []gengo.Field{
@@ -255,6 +260,7 @@ func TestDynamicMessage_RepeatedTypes_ButNoRecursion(t *testing.T) {
 		*gengo.NewField("test", "xMessage", "x2", true, -1),
 	}
 	msgSpec = generateTestSpec(fields)
+	msgSpec.FullName = "zMessage"
 	context.RegisterMsg("zMessage", msgSpec)
 
 	_, err = NewDynamicMessageType("zMessage")
@@ -277,12 +283,14 @@ func TestDynamicMessage_RepeatedBuriedTypes_ButNoRecursion(t *testing.T) {
 		*gengo.NewField("test", "uint8", "val", true, -1),
 	}
 	msgSpec := generateTestSpec(fields)
+	msgSpec.FullName = "xMessage"
 	context.RegisterMsg("xMessage", msgSpec)
 
 	fields = []gengo.Field{
 		*gengo.NewField("test", "xMessage", "x", true, -1),
 	}
 	msgSpec = generateTestSpec(fields)
+	msgSpec.FullName = "yMessage"
 	context.RegisterMsg("yMessage", msgSpec)
 
 	fields = []gengo.Field{
@@ -290,6 +298,7 @@ func TestDynamicMessage_RepeatedBuriedTypes_ButNoRecursion(t *testing.T) {
 		*gengo.NewField("test", "yMessage", "y", true, -1),
 	}
 	msgSpec = generateTestSpec(fields)
+	msgSpec.FullName = "zMessage"
 	context.RegisterMsg("zMessage", msgSpec)
 
 	_, err = NewDynamicMessageType("zMessage")
@@ -636,6 +645,28 @@ func TestDynamicMessage_getNestedTypeFromField_basic(t *testing.T) {
 	}
 	if _, ok := nestedType.nested["found"]; ok == false {
 		t.Fatalf("look up returned the incorrect nested type")
+	}
+}
+
+func TestDynamicMessage_DynamicType_FromSpec(t *testing.T) {
+	fields := []gengo.Field{
+		*gengo.NewField("Testing", "float32", "x", false, 0),
+	}
+	spec := generateTestSpec(fields)
+
+	msgType, err := NewDynamicMessageTypeFromSpec(spec)
+	if err != nil {
+		t.Fatal("could not create dynamic type from spec")
+	}
+	if msgType.spec.FullName != spec.FullName {
+		t.Fatal("type name mismatch")
+	}
+}
+
+func TestDynamicMessage_DynamicType_FromSpec_BadSpec(t *testing.T) {
+	_, err := NewDynamicMessageTypeFromSpec(nil)
+	if err == nil {
+		t.Fatal("expected nil spec to throw an error")
 	}
 }
 

--- a/ros/service_client_test.go
+++ b/ros/service_client_test.go
@@ -403,7 +403,7 @@ func setupServiceServerAndClient(t *testing.T) (net.Listener, net.Conn, *default
 	rootLogger := modular.NewRootLogger(logrus.New())
 
 	logger := rootLogger.GetModuleLogger()
-	logger.SetLevel(logrus.DebugLevel)
+	logger.SetLevel(logrus.WarnLevel)
 
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {


### PR DESCRIPTION
This PR closes https://rocosglobal.atlassian.net/browse/RA-472
This PR closes https://rocosglobal.atlassian.net/browse/RA-492

DynamicActions construct goal, feedback and result types, which are effectively extensions of the `DynamicMessageType`

However, these types do not construct the `DynamicMessageType` correctly, resulting in RA-472. 

The issues in RA-492 were a result of empty strings returning nil instead of `""` by the DynamicMessage. Unchecked casting of fields in `DynamicAction` resulted in the agent panicking.

## Changes
* Add a `NewDynamicMessageTypeFromSpec` constructor to allow `DynamicActions` to construct its types correctly.
* Some minor refactoring of `DynamicMessage` to ensure that the `DynamicMessageType` constructors stay in sync.
* DynamicMessage deserializes empty strings correctly
* Force `NewStatusArrayFromInterface` to check its map accesses and casts

## Results
Actions work again!
<img width="808" alt="image" src="https://user-images.githubusercontent.com/4222666/107603235-f23b6000-6c90-11eb-9b86-32f9e3d6f0a7.png">
