### PR TITLE
RA-474, RA-484: Asynchronous TCPROS Utilities

### DIFF
--- a/ros/header.go
+++ b/ros/header.go
@@ -30,15 +30,20 @@ func readConnectionHeader(r io.Reader) ([]header, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf = make([]byte, int(headerSize))
-	_, err = io.ReadAtLeast(r, buf, int(headerSize))
+
+	return readConnectionHeaderPayload(r, headerSize)
+}
+
+func readConnectionHeaderPayload(r io.Reader, headerSize uint32) ([]header, error) {
+	buf := make([]byte, int(headerSize))
+	_, err := io.ReadAtLeast(r, buf, int(headerSize))
 	if err != nil {
 		return nil, err
 	}
 
 	var done uint32 = 0
 	var headers []header
-	bufReader = bytes.NewBuffer(buf)
+	bufReader := bytes.NewBuffer(buf)
 	for {
 		if done == headerSize {
 			break

--- a/ros/rate_test.go
+++ b/ros/rate_test.go
@@ -17,15 +17,15 @@ func TestNewRate(t *testing.T) {
 }
 
 func TestCycleTime(t *testing.T) {
-	const MeasureTolerance int64 = 1000000
+	const MeasureTolerance int64 = 10000000
 
 	var d Duration
-	d.FromSec(0.01)
+	d.FromSec(0.1)
 	r := CycleTime(d)
 	if !r.actualCycleTime.IsZero() {
 		t.Fail()
 	}
-	if r.expectedCycleTime.ToSec() != 0.01 {
+	if r.expectedCycleTime.ToSec() != 0.1 {
 		t.Fail()
 	}
 
@@ -58,16 +58,16 @@ func TestRateReset(t *testing.T) {
 }
 
 func TestRateSleep(t *testing.T) {
-	// The jitter tolerance (5msec) doesn't have strong basis.
-	const JitterTolerance int64 = 5000000
-	ct := NewDuration(0, 100000000) // 10msec
+	// The jitter tolerance (50msec) doesn't have strong basis.
+	const JitterTolerance int64 = 50000000
+	ct := NewDuration(0, 100000000) // 100msec
 	r := CycleTime(ct)
 	if ct.Cmp(r.ExpectedCycleTime()) != 0 {
 		t.Fail()
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		start := time.Now().UnixNano()
-		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
 		r.Sleep()
 		end := time.Now().UnixNano()
 

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -52,9 +52,11 @@ func TestRemotePublisherConn_ClosesFromSignal(t *testing.T) {
 	defer conn.Close()
 
 	connectToSubscriber(t, conn)
+	<-time.After(time.Duration(50 * time.Millisecond))
 
 	// Signal to close.
 	quitChan <- struct{}{}
+	<-time.After(time.Duration(50 * time.Millisecond))
 
 	// Check that buffer closed.
 	buffer := make([]byte, 1)

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -15,13 +15,13 @@ import (
 
 func TestRemotePublisherConn_DoesConnect(t *testing.T) {
 	topic := "/test/topic"
-	msgType := testMessageType{}
+	msgType := testMessageType{topic}
 
 	l, conn, _, _, _, disconnectedChan := setupRemotePublisherConnTest(t)
 	defer l.Close()
 	defer conn.Close()
 
-	readAndVerifySubscriberHeader(t, conn, topic, msgType) // Test helper from subscription_test.go.
+	readAndVerifySubscriberHeader(t, conn, msgType) // Test helper from subscription_test.go.
 
 	replyHeader := []header{
 		{"topic", topic},

--- a/ros/tcpros_util.go
+++ b/ros/tcpros_util.go
@@ -1,0 +1,87 @@
+package ros
+
+import (
+	"bytes"
+	goContext "context"
+	"net"
+)
+
+type TCPRosReadResult struct {
+	Buf []byte
+	Err error
+}
+
+var decoder ByteDecoder = &LEByteDecoder{}
+
+func readTCPRosSize(ctx goContext.Context, conn net.Conn) (uint32, error) {
+	buf := make([]byte, 4) // TODO: leverage off readTCPRosData to remove duplication
+	index := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return 0, nil
+		default:
+			n, err := conn.Read(buf[index:])
+			if err != nil {
+				return 0, err
+			}
+			index += n
+			if index >= len(buf) {
+				return decoder.DecodeUint32(bytes.NewReader(buf))
+			}
+		}
+	}
+}
+
+func readTCPRosData(ctx goContext.Context, conn net.Conn, size uint32) ([]byte, error) {
+	buf := make([]byte, int(size))
+	index := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, nil
+		default:
+			n, err := conn.Read(buf[index:])
+			if err != nil {
+				return nil, err
+			}
+			index += n
+			if index >= len(buf) {
+				return buf, nil
+			}
+		}
+	}
+}
+
+// readTcpRosMessage is a rosgo library utility for performing common reads of ros messages from a connection.
+// it should always be called as a go routine, and will return an error on the result channel when it returns.
+func readTCPRosMessage(ctx goContext.Context, conn net.Conn, resultChan chan TCPRosReadResult) {
+
+	size, err := readTCPRosSize(ctx, conn)
+
+	select {
+	case <-ctx.Done():
+		return // Bail if the context has been cancelled.
+	default:
+	}
+
+	if err != nil {
+		resultChan <- TCPRosReadResult{nil, err}
+		return
+	}
+
+	// TODO: Error if size is too large
+	data, err := readTCPRosData(ctx, conn, size)
+	select {
+	case <-ctx.Done():
+		return // Bail if the context has been cancelled.
+	default:
+	}
+
+	if err != nil {
+		resultChan <- TCPRosReadResult{nil, err}
+		return
+	}
+
+	resultChan <- TCPRosReadResult{data, nil}
+}

--- a/ros/tcpros_util_test.go
+++ b/ros/tcpros_util_test.go
@@ -1,0 +1,241 @@
+package ros
+
+import (
+	goContext "context"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+// Private test strucutures.
+
+// fakeContext is a context.Context interface fake.
+type fakeContext struct {
+	done chan struct{}
+}
+
+func newFakeContext() *fakeContext {
+	ctx := fakeContext{}
+	ctx.done = make(chan struct{})
+	return &ctx
+}
+
+// Helper for cleanup in a test.
+func (ctx *fakeContext) close(t *testing.T, d time.Duration) {
+	select {
+	case <-time.After(d):
+		t.Fatalf("context did not close on receiver side")
+	case ctx.done <- struct{}{}:
+	}
+}
+
+// Helper for cleanup in a test.
+func (ctx *fakeContext) cleanUp() {
+	close(ctx.done)
+}
+
+// Implementing the Context interface
+func (ctx *fakeContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (ctx *fakeContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *fakeContext) Err() error {
+	return nil
+}
+
+func (ctx *fakeContext) Value(key interface{}) interface{} {
+	return nil
+}
+
+var _ goContext.Context = &fakeContext{}
+
+func intMin(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Fake Connection
+type fakeAddr struct{ string }
+
+func (a *fakeAddr) Network() string {
+	return "tcp"
+}
+
+func (a *fakeAddr) String() string {
+	return a.string
+}
+
+var _ net.Addr = &fakeAddr{""}
+
+type fakeConn struct {
+	readBytes  []byte // Bytes to send on a read request
+	readN      int    // Max bytes to read at once, beyond this is, it will return in chunks
+	readErr    error  // Error to return on a read request
+	writeBytes []byte // Bytes written from the last write request
+	writeN     int    // Maximum allowable bytes to allow written
+	writeError error  // Error to return on a write request
+	localAddr  fakeAddr
+	remoteAddr fakeAddr
+}
+
+func newFakeConn() *fakeConn {
+	c := &fakeConn{}
+	c.readBytes = make([]byte, 0)
+	c.writeBytes = make([]byte, 0)
+	c.localAddr = fakeAddr{"127.0.0.1:1"}
+	c.remoteAddr = fakeAddr{"127.0.0.1:2"}
+	return c
+}
+
+func (c *fakeConn) Read(b []byte) (n int, err error) {
+	if len(c.readBytes) == 0 {
+		return 0, c.readErr
+	}
+	nRead := intMin(c.readN, len(c.readBytes))
+	if c.readN <= 0 {
+		nRead = len(c.readBytes)
+	}
+	nRead = intMin(nRead, len(b))
+
+	n = copy(b, c.readBytes[:nRead])
+	c.readBytes = c.readBytes[n:]
+
+	return n, c.readErr
+}
+
+func (c *fakeConn) Write(b []byte) (n int, err error) {
+	nWrite := intMin(c.writeN, len(b))
+	var appendBytes []byte
+	n = copy(appendBytes, b[:nWrite])
+	c.writeBytes = append(c.writeBytes, appendBytes...)
+
+	return n, c.readErr
+}
+
+func (c *fakeConn) Close() error                       { return nil }
+func (c *fakeConn) LocalAddr() net.Addr                { return &c.localAddr }
+func (c *fakeConn) RemoteAddr() net.Addr               { return &c.remoteAddr }
+func (c *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+var _ net.Conn = &fakeConn{}
+var _ io.Reader = &fakeConn{}
+
+// Tests start here.
+
+func Test_readTCPRosMessage_successfulCases(t *testing.T) {
+	testCases := []struct {
+		bytes    []byte
+		expected []byte
+	}{
+		{ // Zero data case
+			[]byte{0x00, 0x00, 0x00, 0x00},
+			[]byte{},
+		},
+		{ // Has data case
+			[]byte{0x02, 0x00, 0x00, 0x00, 'a', 'b'},
+			[]byte{'a', 'b'},
+		},
+	}
+
+	resultChan := make(chan TCPRosReadResult)
+	ctx := newFakeContext()
+
+	for i, testCase := range testCases {
+		conn := newFakeConn()
+		conn.readBytes = testCase.bytes
+		go readTCPRosMessage(ctx, conn, resultChan)
+
+		for {
+			<-time.After(time.Millisecond)
+			if len(conn.readBytes) == 0 {
+				break
+			}
+		}
+
+		select {
+		case result := <-resultChan:
+			if result.Err != nil {
+				t.Fatalf("[%d]: unexepected error %v", i, result.Err)
+			}
+			if result.Buf == nil {
+				t.Fatalf("[%d]: result buffer is nil", i)
+			} else if string(result.Buf) != string(testCase.expected) {
+				t.Fatalf("[%d]: buffer mismatch. Result: %v, expected: %v", i, result.Buf, testCase.expected)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Fatalf("[%d]: expected to receive result", i)
+		}
+	}
+	ctx.cleanUp()
+}
+
+func Test_readTCPRosMessage_whenCancelled_isSilent(t *testing.T) {
+	resultChan := make(chan TCPRosReadResult)
+	ctx := newFakeContext()
+	conn := newFakeConn()
+
+	go readTCPRosMessage(ctx, conn, resultChan)
+
+	ctx.close(t, time.Second)
+
+	select {
+	case <-resultChan:
+		t.Fatal("expected cancelled read to close silently")
+	case <-time.After(200 * time.Millisecond):
+	}
+	ctx.cleanUp()
+}
+
+func Test_readTCPRosMessage_whenEoFError_returnsError(t *testing.T) {
+	resultChan := make(chan TCPRosReadResult)
+	ctx := newFakeContext()
+	conn := newFakeConn()
+	conn.readErr = io.EOF
+	go readTCPRosMessage(ctx, conn, resultChan)
+
+	select {
+	case result := <-resultChan:
+		if result.Err != io.EOF {
+			t.Fatalf("unexepected error %v", result.Err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected to receive conn error")
+	}
+	ctx.cleanUp()
+}
+
+func Test_readTCPRosMessage_whenTimeoutErrorDuringSize_returnsError(t *testing.T) {
+	resultChan := make(chan TCPRosReadResult)
+	ctx := newFakeContext()
+	conn := newFakeConn()
+	conn.readBytes = []byte{0x00, 0x00, 0x00} // One read short of getting size
+	go readTCPRosMessage(ctx, conn, resultChan)
+
+	for {
+		<-time.After(time.Millisecond)
+		if len(conn.readBytes) == 0 {
+			break
+		}
+	}
+	conn.readErr = os.ErrDeadlineExceeded
+
+	select {
+	case result := <-resultChan:
+		if result.Err != os.ErrDeadlineExceeded {
+			t.Fatalf("unexepected error %v", result.Err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected to receive conn error")
+	}
+	ctx.cleanUp()
+}


### PR DESCRIPTION
Closes https://rocosglobal.atlassian.net/browse/RA-474
Closes https://rocosglobal.atlassian.net/browse/RA-484

## Changes
* Add `tcpros_util.go` which has two general read/write routines:
  * `readTCPRosMessage`, general purpose TCPROS message reader go routine
    * returns result on a channel
    * takes a `context.Context` to allow tree cancellation
    * allows low-latency cancellation at any stage of the read
    * read timeouts are shortened (100ms)... though we would probably get away with lower latency if we wanted it
    * can drip feed a large packet over a looong period so we are more robust to random failures caused by spurious network  loads.
  * `writeTCPRosMessage`
    * the same benefits as`readTCPRosMessage`
  * `writeTCPRosMessage` is only applied to `subscription` in this PR... however actions and services would benefit from this too.
* add `net.Conn` fake
  * this was extremely useful for testing the guts out of `tcpros_util`, and keeps test running time low... ideally, apply this fake for other tests which need a `net.Conn`
* use `readTCPRosMessage` and `writeTCPRosMessage` to `subscription.go`
  * we now have the start of using a `context.Context` tree structure ready to go in `subscription.go`
  * subscriptions are much more responsive to enables and cancellation (almost zero latency vs 1sec latency since the reads are handled in a separate go routine)
  * subscriptions are less likely to drop packets due to partial reads (unless the network really sucks)
  * subscriptions can be cancelled during header exchange

## Integration Testing
Current integration testing has just involved running some turtlebot actions with a subscription to `pose`. Both interval and non-interval cases are working.

<img width="766" alt="image" src="https://user-images.githubusercontent.com/4222666/108165953-527e4600-7158-11eb-99b5-afb51f2f62a0.png">

