### PR TITLE
Apply safe shutdown of dead subscriptions

### DIFF
--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -66,7 +66,10 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 			newPubs := setDifference(list, sub.pubList)
 			sub.pubList = list
 			for _, pub := range deadPubs {
-				delete(sub.subscriptionChans, pub)
+				if channels, ok := sub.subscriptionChans[pub]; ok {
+					close(channels.quit)
+					delete(sub.subscriptionChans, pub)
+				}
 			}
 
 			for _, pub := range newPubs {


### PR DESCRIPTION
Addresses https://rocosglobal.atlassian.net/browse/RA-497

Safely closes any hanging subscriptions.

When the deadPubs list is being handled, the following scenarios may be in play:
* the subscription has already detected that the publisher is not alive and has shut down
  * this is the root cause of the original defect in RA-497, resulting in a channel hanging on close
  * the subscription may or may not have already notified subscriber, and so the subscriptionsChan map may has already deleted the channels for that particular publisher
* the subscription has not detected that the publisher is dead, and needs to be told to close

Also added a sneaky debug log on an area of subscriptions that will expose potential latency issues

No leaks
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/4222666/108781598-06575980-75cf-11eb-8c8a-760491d4f8f5.png">

No freezing on topic unsubs.
![image](https://user-images.githubusercontent.com/4222666/108781633-12431b80-75cf-11eb-877a-c88e63776fbd.png)


