### PR TITLE
RA509 - Responsive Subscriptions by removing the job queue

### DIFF
--- a/ros/node.go
+++ b/ros/node.go
@@ -231,7 +231,7 @@ func newDefaultNode(name string, args []string) (*defaultNode, error) {
 			node.okMutex.Unlock()
 		}()
 	}
-	node.jobChan = make(chan func(), 100)
+	node.jobChan = make(chan func())
 
 	logger.Debugf("Master URI = %s", node.masterURI)
 

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -251,22 +251,28 @@ func startRemotePublisherConn(ctx goContext.Context, dialer TCPRosDialer,
 	sub.startWithContext(ctx, log)
 }
 
-// TODO: Put tests on this
+// setDifference returns the difference of two "sets" represented by string arrays.
 func setDifference(lhs []string, rhs []string) []string {
-	left := map[string]bool{}
-	for _, item := range lhs {
-		left[item] = true
+	result := make([]string, 0)
+	for _, entry := range lhs {
+		hasEntry := false
+		for _, nEntry := range rhs {
+			if entry == nEntry {
+				hasEntry = true
+				break
+			}
+		}
+		if hasEntry == false {
+			result = append(result, entry)
+		}
 	}
-	right := map[string]bool{}
-	for _, item := range rhs {
-		right[item] = true
-	}
-	for k := range right {
-		delete(left, k)
-	}
-	var result []string
-	for k := range left {
-		result = append(result, k)
+	// Dedup
+	for i, entry := range result {
+		for j := i + 1; j < len(result); j++ {
+			if entry == result[j] {
+				result = append(result[:j], result[j+1:]...)
+			}
+		}
 	}
 	return result
 }

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -87,7 +87,7 @@ func newDefaultSubscriber(topic string, msgType MessageType, callback interface{
 	sub.msgType = msgType
 	sub.msgChan = make(chan messageEvent)
 	sub.pubListChan = make(chan []string, 10)
-	sub.addCallbackChan = make(chan interface{}, 10)
+	sub.addCallbackChan = make(chan interface{})
 	sub.shutdownChan = make(chan struct{})
 	sub.disconnectedChan = make(chan string, 10)
 	sub.callbacks = []interface{}{callback}
@@ -210,11 +210,12 @@ func (sub *defaultSubscriber) run(ctx goContext.Context, jobChan chan func(), en
 					fun := reflect.ValueOf(callback)
 					numArgsNeeded := fun.Type().NumIn()
 					if numArgsNeeded <= 2 {
-						fun.Call(args[0:numArgsNeeded])
+						fun.Call(args[:numArgsNeeded])
 					}
 				}
 			}
 			activeJobChan = jobChan
+
 		case activeJobChan <- latestJob:
 			logger.Debug(sub.topic, " : Callback job enqueued.")
 			activeJobChan = nil

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -4,6 +4,7 @@ import (
 	goContext "context"
 	"io"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -451,10 +452,29 @@ func TestSubscriber_Run_JobPrioritization(t *testing.T) {
 }
 
 // TODO tests:
-// - job channel prioritization
 // - add publishers
 // - remove publishers (through disconnection)
 // -
+
+func TestSetDifference(t *testing.T) {
+	testSetDifference := func(lhs []string, rhs []string, expected []string) {
+		if result := setDifference(lhs, rhs); reflect.DeepEqual(expected, result) == false {
+			t.Fatalf("setDifference(%v, %v) failed, expected %v, got %v", lhs, rhs, expected, result)
+		}
+	}
+
+	testSetDifference([]string{"a", "b", "c"}, []string{"a", "b", "c"}, []string{})
+	testSetDifference([]string{"a", "b", "c"}, []string{"a", "b"}, []string{"c"})
+	testSetDifference([]string{"a", "b", "c"}, []string{"c", "b"}, []string{"a"})
+	testSetDifference([]string{}, []string{"a", "b", "c"}, []string{})
+	testSetDifference([]string{"a", "b", "c"}, []string{}, []string{"a", "b", "c"})
+	testSetDifference([]string{"I", "am", "Sam"}, []string{"Sam", "I", "am"}, []string{})
+	testSetDifference([]string{"She", "sells", "sea"}, []string{"shells", "on", "the", "sea", "shore"}, []string{"She", "sells"})
+	testSetDifference([]string{"a", "a", "b", "b"}, []string{"b"}, []string{"a"})
+	testSetDifference([]string{"a", "a", "b", "b"}, []string{"a"}, []string{"b"})
+	testSetDifference([]string{"a", "b", "b"}, []string{"a", "a"}, []string{"b"})
+
+}
 
 // Test Helpers
 

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -164,7 +164,7 @@ func TestSubscriber_Run_Shutdown(t *testing.T) {
 		t.Fatal("shutdown response failed")
 	}
 
-	<-time.After(10 * time.Millisecond) // give the unregister call a moment
+	<-time.After(10 * time.Millisecond) // Give the unregister call a moment.
 	if rosAPI.unregistered == false {
 		t.Fatal("did not unregister on shutdown")
 	}
@@ -530,7 +530,7 @@ func TestSubscriber_Run_Publishers(t *testing.T) {
 		t.Fatalf("expected pubList to match current publishers, got %v", sub.pubList)
 	}
 
-	// Add pub3 again
+	// Add pub3 back again.
 	sub.pubListChan <- pubSend
 
 	// Delay so publisher list is picked up.
@@ -589,7 +589,7 @@ func TestSubscriber_Run_AddPublishersDontBlock(t *testing.T) {
 	// Shutdown the subscription - checks that all subscriptions are cancelled.
 	go sub.Shutdown()
 
-	// Check first context is cancelled
+	// Check first context is cancelled.
 	select {
 	case <-shutdownSubscriber:
 	case <-time.After(50 * time.Millisecond):
@@ -614,18 +614,19 @@ func TestSubscriber_Run_AddPublisherOverride(t *testing.T) {
 	go sub.run(ctx, jobChan, enableChan, rosAPI, startSubscription, log)
 	defer sub.Shutdown()
 
+	pubSend1 := []string{"pub1", "pub2"}
+	pubSend2 := []string{"pub3"}
+
 	// Send publishers.
-	pubSend := []string{"pub1", "pub2"}
-	sub.pubListChan <- pubSend
+	sub.pubListChan <- pubSend1
 
 	// Override publishers
-	pubSend = []string{"pub3"}
-	sub.pubListChan <- pubSend
+	sub.pubListChan <- pubSend2
 
-	// wait for published channels to take effect
+	// Wait for published channels to take effect.
 	<-time.After(60 * time.Millisecond)
 
-	if reflect.DeepEqual(sub.pubList, []string{"pub3"}) == false {
+	if reflect.DeepEqual(sub.pubList, pubSend2) == false {
 		t.Fatalf("expected pubList to match sent publishers, got %v", sub.pubList)
 	}
 
@@ -653,7 +654,7 @@ func TestSetDifference(t *testing.T) {
 	testSetDifference([]string{"a", "b", "b"}, []string{"a", "a"}, []string{"b"})
 }
 
-// Test Helpers
+// Test Helpers.
 
 // makeTestSubscriber creates a subscriber with a simple u8[8] payload message type.
 func makeTestSubscriber() *defaultSubscriber {

--- a/ros/subscriber_test.go
+++ b/ros/subscriber_test.go
@@ -1,6 +1,7 @@
 package ros
 
 import (
+	goContext "context"
 	"io"
 	"net"
 	"testing"
@@ -130,12 +131,12 @@ func TestSubscriber_Run_Shutdown(t *testing.T) {
 	jobChan := make(chan func())
 	enableChan := make(chan bool)
 	rosAPI := newFakeSubscriberRos()
-	nodeID := "testNode"
+	startSubscription := func(ctx goContext.Context, pubURI string, log *modular.ModuleLogger) {}
 	log := makeTestLogger()
 
 	shutdownSubscriber := make(chan struct{})
 	go func() {
-		sub.run(ctx, jobChan, enableChan, rosAPI, nodeID, log)
+		sub.run(ctx, jobChan, enableChan, rosAPI, startSubscription, log)
 		shutdownSubscriber <- struct{}{}
 	}()
 
@@ -168,12 +169,12 @@ func TestSubscriber_Run_FlowControl(t *testing.T) {
 	jobChan := make(chan func())
 	enableChan := make(chan bool)
 	rosAPI := newFakeSubscriberRos()
-	nodeID := "testNode"
 	log := makeTestLogger()
+	startSubscription := func(ctx goContext.Context, pubURI string, log *modular.ModuleLogger) {}
 
 	shutdownSubscriber := make(chan struct{})
 	go func() {
-		sub.run(ctx, jobChan, enableChan, rosAPI, nodeID, log)
+		sub.run(ctx, jobChan, enableChan, rosAPI, startSubscription, log)
 		shutdownSubscriber <- struct{}{}
 	}()
 
@@ -214,6 +215,12 @@ func TestSubscriber_Run_FlowControl(t *testing.T) {
 		t.Fatal("expected job from enabled channel")
 	}
 }
+
+// TODO tests:
+// - job channel prioritization
+// - add publishers
+// - remove publishers (through disconnection)
+// -
 
 // Test Helpers
 
@@ -256,7 +263,7 @@ func setupRemotePublisherConnTest(t *testing.T) (*fakeContext, net.Conn, chan me
 	msgType := testMessageType{}
 	log := makeTestLogger()
 
-	startRemotePublisherConn(ctx, log, testDialer, pubURI, topic, msgType, nodeID, msgChan, disconnectedChan)
+	startRemotePublisherConn(ctx, testDialer, pubURI, topic, msgType, nodeID, msgChan, disconnectedChan, log)
 
 	return ctx, pubConn, msgChan, disconnectedChan
 }

--- a/ros/subscription.go
+++ b/ros/subscription.go
@@ -295,7 +295,7 @@ func (s *defaultSubscription) readFromPublisher(ctx goContext.Context, conn net.
 			switch rResult {
 			case readResultOk:
 				if activeMsgChan != nil {
-					logger.WithFields(logrus.Fields{"topic": s.topic}).Debug("stale message dropped")
+					logger.WithFields(logrus.Fields{"topic": s.topic}).Trace("stale message dropped")
 				}
 				s.event.ReceiptTime = time.Now()
 				latestMessage = messageEvent{bytes: tcpResult.Buf, event: s.event}


### PR DESCRIPTION
Closes https://rocosglobal.atlassian.net/browse/RA-509

Also closes https://rocosglobal.atlassian.net/browse/RA-479

The primary purpose of this MR was to improve rosgo's responsiveness to telemetry, and only provide the latest ROSGO messages.

## Changes

* Updates to subscriber
  * Subscriber loop is decoupled from external calls
    * Allows thorough testing of the subscriber concurrency loop
  * Subscriber loop no longer needs buffered channels
    * All busy waits either spawn their own go routine (with channels to communicate) or are eliminated all together
    * Allows us to be very responsive to any channel update - expected (though difficult to prove) more responsive flow control
  * Drops old jobs in favor of new jobs - the telemetry which will reach the agent will always be the latest telemetry
    * Allows immediate shutdowns
    * No more temporary "deadlock" when the job queue fills up and we wait for 3 seconds for it to empty (meanwhile it can be blocked by waiting for the subscriber to receive on an `enable` channel
  * Removed new publisher list bug; `setDifference` now returns an empty list when there is no difference
  * Removed subscription shutdown bug; if a subscriptions drops out from a publisher, and we receive that publisher in a publisher list update, we will now reconnect to it rather than ignore it
* Other updates
  * Job channel is no longer a queue

## Performance

This PR did not expect to improve overall performance, only responsiveness (which is proven in unit testing of subscriber).

Performance was tested with subscriptions to both a point cloud and odometer readings.

Testing shows no noticeable change in performance.

Agent performance with this branch:

![Screen Shot 2021-03-09 at 11 40 38 AM](https://user-images.githubusercontent.com/4222666/110395403-ec3f7000-80d2-11eb-925c-4404a0b96853.png)

Agent performance with master branch:

![Screen Shot 2021-03-09 at 11 48 30 AM](https://user-images.githubusercontent.com/4222666/110395409-eea1ca00-80d2-11eb-9014-6e47e0146097.png)

