### PR TITLE
Ra 643 deserialize bugs

### DIFF
--- a/ros/byte_decoder_le.go
+++ b/ros/byte_decoder_le.go
@@ -13,16 +13,30 @@ type LEByteDecoder struct{}
 
 var _ ByteDecoder = LEByteDecoder{}
 
+// Helpers
+
+func CheckSize(buf *bytes.Reader, size int) error {
+	if size < 0 {
+		return errors.New("unexpected negative size")
+	}
+	if buf.Len() < size {
+		return errors.New("buffer size too small")
+	}
+	return nil
+}
+
 // Array decoders.
 
 // DecodeBoolArray decodes an array of boolean values.
 func (d LEByteDecoder) DecodeBoolArray(buf *bytes.Reader, size int) ([]bool, error) {
+	if err := CheckSize(buf, size); err != nil {
+		return nil, errors.Wrap(err, "decoding bool array")
+	}
+
 	var arr [1]byte
-	var n int
-	var err error
 	slice := make([]bool, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 1 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 1 || err != nil {
 			return slice, errors.New("Could not read 1 byte from buffer")
 		}
 		slice[i] = (arr[0] != 0x00)
@@ -32,12 +46,14 @@ func (d LEByteDecoder) DecodeBoolArray(buf *bytes.Reader, size int) ([]bool, err
 
 // DecodeInt8Array decodes an array of int8 values.
 func (d LEByteDecoder) DecodeInt8Array(buf *bytes.Reader, size int) ([]int8, error) {
+	if err := CheckSize(buf, size); err != nil {
+		return nil, errors.Wrap(err, "decoding i8 array")
+	}
+
 	var arr [1]byte
-	var n int
-	var err error
 	slice := make([]int8, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 1 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 1 || err != nil {
 			return slice, errors.New("Could not read 1 byte from buffer")
 		}
 		slice[i] = int8(arr[0])
@@ -48,14 +64,16 @@ func (d LEByteDecoder) DecodeInt8Array(buf *bytes.Reader, size int) ([]int8, err
 
 // DecodeUint8Array decodes an array of uint8 values.
 func (d LEByteDecoder) DecodeUint8Array(buf *bytes.Reader, size int) ([]uint8, error) {
-	var err error
-	var n int
+	if err := CheckSize(buf, size); err != nil {
+		return nil, errors.Wrap(err, "decoding u8 array")
+	}
+
 	slice := make([]uint8, size)
 	if size == 0 {
 		// Early return to avoid potentail EOF error.
 		return slice, nil
 	}
-	n, err = buf.Read(slice)
+	n, err := buf.Read(slice)
 	if n != size || err != nil {
 		return slice, errors.New("Did not read entire uint8 buffer")
 	}
@@ -65,12 +83,14 @@ func (d LEByteDecoder) DecodeUint8Array(buf *bytes.Reader, size int) ([]uint8, e
 
 // DecodeInt16Array decodes an array of int16 values.
 func (d LEByteDecoder) DecodeInt16Array(buf *bytes.Reader, size int) ([]int16, error) {
+	if err := CheckSize(buf, size*2); err != nil {
+		return nil, errors.Wrap(err, "decoding i16 array")
+	}
+
 	var arr [2]byte
-	var n int
-	var err error
 	slice := make([]int16, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 2 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 2 || err != nil {
 			return slice, errors.New("Could not read 2 bytes from buffer")
 		}
 		slice[i] = int16(binary.LittleEndian.Uint16(arr[:]))
@@ -81,12 +101,14 @@ func (d LEByteDecoder) DecodeInt16Array(buf *bytes.Reader, size int) ([]int16, e
 
 // DecodeUint16Array decodes an array of uint16 values.
 func (d LEByteDecoder) DecodeUint16Array(buf *bytes.Reader, size int) ([]uint16, error) {
+	if err := CheckSize(buf, size*2); err != nil {
+		return nil, errors.Wrap(err, "decoding u16 array")
+	}
+
 	var arr [2]byte
-	var n int
-	var err error
 	slice := make([]uint16, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 2 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 2 || err != nil {
 			return slice, errors.New("Could not read 2 bytes from buffer")
 		}
 		slice[i] = binary.LittleEndian.Uint16(arr[:])
@@ -97,12 +119,14 @@ func (d LEByteDecoder) DecodeUint16Array(buf *bytes.Reader, size int) ([]uint16,
 
 // DecodeInt32Array decodes an array of int32 values.
 func (d LEByteDecoder) DecodeInt32Array(buf *bytes.Reader, size int) ([]int32, error) {
+	if err := CheckSize(buf, size*4); err != nil {
+		return nil, errors.Wrap(err, "decoding i32 array")
+	}
+
 	var arr [4]byte
-	var n int
-	var err error
 	slice := make([]int32, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 4 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 4 || err != nil {
 			return slice, errors.New("Could not read 4 bytes from buffer")
 		}
 		slice[i] = int32(binary.LittleEndian.Uint32(arr[:]))
@@ -113,12 +137,14 @@ func (d LEByteDecoder) DecodeInt32Array(buf *bytes.Reader, size int) ([]int32, e
 
 // DecodeUint32Array decodes an array of uint32 values.
 func (d LEByteDecoder) DecodeUint32Array(buf *bytes.Reader, size int) ([]uint32, error) {
+	if err := CheckSize(buf, size*4); err != nil {
+		return nil, errors.Wrap(err, "decoding u32 array")
+	}
+
 	var arr [4]byte
-	var n int
-	var err error
 	slice := make([]uint32, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 4 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 4 || err != nil {
 			return slice, errors.New("Could not read 4 bytes from buffer")
 		}
 		slice[i] = binary.LittleEndian.Uint32(arr[:])
@@ -129,13 +155,15 @@ func (d LEByteDecoder) DecodeUint32Array(buf *bytes.Reader, size int) ([]uint32,
 
 // DecodeFloat32Array decodes an array of float32 values.
 func (d LEByteDecoder) DecodeFloat32Array(buf *bytes.Reader, size int) ([]JsonFloat32, error) {
+	if err := CheckSize(buf, size*4); err != nil {
+		return nil, errors.Wrap(err, "decoding f32 array")
+	}
+
 	var arr [4]byte
-	var n int
-	var err error
 	var value float32
 	slice := make([]JsonFloat32, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 4 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 4 || err != nil {
 			return slice, errors.New("Could not read 4 bytes from buffer")
 		}
 		value = math.Float32frombits(binary.LittleEndian.Uint32(arr[:]))
@@ -147,12 +175,14 @@ func (d LEByteDecoder) DecodeFloat32Array(buf *bytes.Reader, size int) ([]JsonFl
 
 // DecodeInt64Array decodes an array of int64 values.
 func (d LEByteDecoder) DecodeInt64Array(buf *bytes.Reader, size int) ([]int64, error) {
+	if err := CheckSize(buf, size*8); err != nil {
+		return nil, errors.Wrap(err, "decoding i64 array")
+	}
+
 	var arr [8]byte
-	var n int
-	var err error
 	slice := make([]int64, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 8 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 8 || err != nil {
 			return slice, errors.New("Could not read 8 bytes from buffer")
 		}
 		slice[i] = int64(binary.LittleEndian.Uint64(arr[:]))
@@ -163,12 +193,14 @@ func (d LEByteDecoder) DecodeInt64Array(buf *bytes.Reader, size int) ([]int64, e
 
 // DecodeUint64Array decodes an array of uint64 values.
 func (d LEByteDecoder) DecodeUint64Array(buf *bytes.Reader, size int) ([]uint64, error) {
+	if err := CheckSize(buf, size*8); err != nil {
+		return nil, errors.Wrap(err, "decoding u64 array")
+	}
+
 	var arr [8]byte
-	var n int
-	var err error
 	slice := make([]uint64, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 8 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 8 || err != nil {
 			return slice, errors.New("Could not read 8 bytes from buffer")
 		}
 		slice[i] = binary.LittleEndian.Uint64(arr[:])
@@ -179,13 +211,15 @@ func (d LEByteDecoder) DecodeUint64Array(buf *bytes.Reader, size int) ([]uint64,
 
 // DecodeFloat64Array decodes an array of float64 values.
 func (d LEByteDecoder) DecodeFloat64Array(buf *bytes.Reader, size int) ([]JsonFloat64, error) {
+	if err := CheckSize(buf, size*8); err != nil {
+		return nil, errors.Wrap(err, "decoding f64 array")
+	}
+
 	var arr [8]byte
-	var n int
-	var err error
 	var value float64
 	slice := make([]JsonFloat64, size)
 	for i := 0; i < size; i++ {
-		if n, err = buf.Read(arr[:]); n != 8 || err != nil {
+		if n, err := buf.Read(arr[:]); n != 8 || err != nil {
 			return slice, errors.New("Could not read 8 bytes from buffer")
 		}
 		value = math.Float64frombits(binary.LittleEndian.Uint64(arr[:]))
@@ -197,19 +231,20 @@ func (d LEByteDecoder) DecodeFloat64Array(buf *bytes.Reader, size int) ([]JsonFl
 
 // DecodeStringArray decodes an array of strings.
 func (d LEByteDecoder) DecodeStringArray(buf *bytes.Reader, size int) ([]string, error) {
-	var strSize uint32
-	var err error
 
 	// String format is: [size|string] where size is a u32.
 	slice := make([]string, size)
 	for i := 0; i < size; i++ {
+		var strSize uint32
+		var err error
 		if strSize, err = d.DecodeUint32(buf); err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding string array")
 		}
+
 		var value []uint8
 		value, err = d.DecodeUint8Array(buf, int(strSize))
 		if err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding string array")
 		}
 		slice[i] = string(value)
 	}
@@ -218,16 +253,19 @@ func (d LEByteDecoder) DecodeStringArray(buf *bytes.Reader, size int) ([]string,
 
 // DecodeTimeArray decodes an array of Time structs.
 func (d LEByteDecoder) DecodeTimeArray(buf *bytes.Reader, size int) ([]Time, error) {
-	var err error
+	if err := CheckSize(buf, size*8); err != nil {
+		return nil, errors.Wrap(err, "decoding time array")
+	}
 
 	// Time format is: [sec|nanosec] where sec and nanosec are unsigned integers.
 	slice := make([]Time, size)
 	for i := 0; i < size; i++ {
+		var err error
 		if slice[i].Sec, err = d.DecodeUint32(buf); err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding time array")
 		}
 		if slice[i].NSec, err = d.DecodeUint32(buf); err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding time array")
 		}
 	}
 	return slice, nil
@@ -235,16 +273,19 @@ func (d LEByteDecoder) DecodeTimeArray(buf *bytes.Reader, size int) ([]Time, err
 
 // DecodeDurationArray decodes an array of Duration structs.
 func (d LEByteDecoder) DecodeDurationArray(buf *bytes.Reader, size int) ([]Duration, error) {
-	var err error
+	if err := CheckSize(buf, size*8); err != nil {
+		return nil, errors.Wrap(err, "decoding duration array")
+	}
 
 	// Duration format is: [sec|nanosec] where sec and nanosec are unsigned integers.
 	slice := make([]Duration, size)
 	for i := 0; i < size; i++ {
+		var err error
 		if slice[i].Sec, err = d.DecodeUint32(buf); err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding duration array")
 		}
 		if slice[i].NSec, err = d.DecodeUint32(buf); err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding duration array")
 		}
 	}
 	return slice, nil
@@ -259,7 +300,7 @@ func (d LEByteDecoder) DecodeMessageArray(buf *bytes.Reader, size int, msgType *
 		msg := &DynamicMessage{}
 		msg.dynamicType = msgType
 		if err := msg.Deserialize(buf); err != nil {
-			return slice, err
+			return slice, errors.Wrap(err, "decoding message array")
 		}
 		slice[i] = msg
 	}
@@ -360,11 +401,11 @@ func (d LEByteDecoder) DecodeString(buf *bytes.Reader) (string, error) {
 	var strSize uint32
 	// String format is: [size|string] where size is a u32.
 	if strSize, err = d.DecodeUint32(buf); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "decoding string")
 	}
 	var value []uint8
 	if value, err = d.DecodeUint8Array(buf, int(strSize)); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "decoding string")
 	}
 	return string(value), nil
 }
@@ -376,10 +417,10 @@ func (d LEByteDecoder) DecodeTime(buf *bytes.Reader) (Time, error) {
 
 	// Time format is: [sec|nanosec] where sec and nanosec are unsigned integers.
 	if value.Sec, err = d.DecodeUint32(buf); err != nil {
-		return Time{}, err
+		return Time{}, errors.Wrap(err, "decoding time")
 	}
 	if value.NSec, err = d.DecodeUint32(buf); err != nil {
-		return Time{}, err
+		return Time{}, errors.Wrap(err, "decoding time")
 	}
 
 	return value, nil
@@ -392,10 +433,10 @@ func (d LEByteDecoder) DecodeDuration(buf *bytes.Reader) (Duration, error) {
 
 	// Duration format is: [sec|nanosec] where sec and nanosec are unsigned integers.
 	if value.Sec, err = d.DecodeUint32(buf); err != nil {
-		return Duration{}, err
+		return Duration{}, errors.Wrap(err, "decoding duration")
 	}
 	if value.NSec, err = d.DecodeUint32(buf); err != nil {
-		return Duration{}, err
+		return Duration{}, errors.Wrap(err, "decoding duration")
 	}
 
 	return value, nil
@@ -407,7 +448,7 @@ func (d LEByteDecoder) DecodeMessage(buf *bytes.Reader, msgType *DynamicMessageT
 	msg := &DynamicMessage{}
 	msg.dynamicType = msgType
 	if err := msg.Deserialize(buf); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "decoding message")
 	}
 
 	return msg, nil

--- a/ros/byte_decoder_le.go
+++ b/ros/byte_decoder_le.go
@@ -231,6 +231,10 @@ func (d LEByteDecoder) DecodeFloat64Array(buf *bytes.Reader, size int) ([]JsonFl
 
 // DecodeStringArray decodes an array of strings.
 func (d LEByteDecoder) DecodeStringArray(buf *bytes.Reader, size int) ([]string, error) {
+	// Use minimum string byte size = 4
+	if err := CheckSize(buf, size*4); err != nil {
+		return nil, errors.Wrap(err, "decoding string array")
+	}
 
 	// String format is: [size|string] where size is a u32.
 	slice := make([]string, size)
@@ -293,6 +297,11 @@ func (d LEByteDecoder) DecodeDurationArray(buf *bytes.Reader, size int) ([]Durat
 
 // DecodeMessageArray decodes an array of DynamicMessages.
 func (d LEByteDecoder) DecodeMessageArray(buf *bytes.Reader, size int, msgType *DynamicMessageType) ([]Message, error) {
+	// Not an exact check, but at least prevents an impossible allocation
+	if err := CheckSize(buf, size); err != nil {
+		return nil, errors.Wrap(err, "decoding message array")
+	}
+
 	slice := make([]Message, size)
 
 	for i := 0; i < size; i++ {

--- a/ros/byte_decoder_le_test.go
+++ b/ros/byte_decoder_le_test.go
@@ -1,0 +1,221 @@
+package ros
+
+import (
+	"bytes"
+	"testing"
+
+	gengo "github.com/team-rocos/rosgo/libgengo"
+)
+
+func TestCheckSize(t *testing.T) {
+	raw := make([]byte, 10)
+	buffer := bytes.NewReader(raw)
+
+	if err := CheckSize(buffer, -1); err == nil {
+		t.Fatalf("negative size should result in error")
+	}
+
+	if err := CheckSize(buffer, 9); err != nil {
+		t.Fatalf("expected pass")
+	}
+
+	if err := CheckSize(buffer, 10); err != nil {
+		t.Fatalf("exact match should pass")
+	}
+
+	if err := CheckSize(buffer, 11); err == nil {
+		t.Fatalf("size greater than buffer should fail")
+	}
+
+	read := make([]byte, 10)
+	buffer.Read(read)
+
+	if err := CheckSize(buffer, -1); err == nil {
+		t.Fatalf("negative size should result in error")
+	}
+
+	if err := CheckSize(buffer, 0); err != nil {
+		t.Fatalf("exact match should pass")
+	}
+
+	if err := CheckSize(buffer, 1); err == nil {
+		t.Fatalf("size greater than buffer should fail")
+	}
+}
+
+func TestDecoder_BufferTooSmall(t *testing.T) {
+	raw := make([]byte, 0)
+	buffer := bytes.NewReader(raw)
+	d := LEByteDecoder{}
+
+	fields := []gengo.Field{
+		*gengo.NewField("Testing", "uint8", "v", false, 0),
+	}
+	testMessageType := &DynamicMessageType{
+		spec:         generateTestSpec(fields),
+		nested:       make(map[string]*DynamicMessageType),
+		jsonPrealloc: 0,
+	}
+
+	if _, err := d.DecodeBoolArray(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt8Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt16Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt32Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt64Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint8Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint16Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint32Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint64Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeFloat32Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeFloat64Array(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeStringArray(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeTimeArray(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeDurationArray(buffer, 1); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeMessageArray(buffer, 1, testMessageType); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeBool(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt8(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt16(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt32(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt64(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint8(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint16(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint32(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint64(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeFloat32(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeFloat64(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeString(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeTime(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeDuration(buffer); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeMessage(buffer, testMessageType); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+
+}
+
+func TestDecoder_BufferExactSize(t *testing.T) {
+	raw := []byte{0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	buffer := bytes.NewReader(raw)
+	d := LEByteDecoder{}
+
+	if _, err := d.DecodeBoolArray(buffer, 16); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeInt8Array(buffer, 16); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeInt16Array(buffer, 8); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeInt32Array(buffer, 4); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeInt64Array(buffer, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeUint8Array(buffer, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeUint16Array(buffer, 8); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeUint32Array(buffer, 4); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeUint64Array(buffer, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeFloat32Array(buffer, 4); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeFloat64Array(buffer, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeStringArray(buffer, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buffer = bytes.NewReader(raw)
+	if _, err := d.DecodeTimeArray(buffer, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/ros/byte_decoder_le_test.go
+++ b/ros/byte_decoder_le_test.go
@@ -150,6 +150,69 @@ func TestDecoder_BufferTooSmall(t *testing.T) {
 
 }
 
+func TestDecoder_DangerousSize(t *testing.T) {
+	raw := make([]byte, 20)
+	buffer := bytes.NewReader(raw)
+	d := LEByteDecoder{}
+
+	fields := []gengo.Field{
+		*gengo.NewField("Testing", "uint8", "v", false, 0),
+	}
+	testMessageType := &DynamicMessageType{
+		spec:         generateTestSpec(fields),
+		nested:       make(map[string]*DynamicMessageType),
+		jsonPrealloc: 0,
+	}
+
+	// These test cases are designed to cause the tester to throw if we preallocate without checking size.
+
+	if _, err := d.DecodeBoolArray(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt8Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt16Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt32Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeInt64Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint8Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint16Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint32Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeUint64Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeFloat32Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeFloat64Array(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeStringArray(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeTimeArray(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeDurationArray(buffer, 1e9); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+	if _, err := d.DecodeMessageArray(buffer, 1e9, testMessageType); err == nil {
+		t.Fatal("did not error for buffer too small")
+	}
+}
+
 func TestDecoder_BufferExactSize(t *testing.T) {
 	raw := []byte{0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	buffer := bytes.NewReader(raw)

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -245,6 +245,7 @@ func (sub *defaultSubscriber) run(ctx goContext.Context, jobChan chan func(), en
 				reader := bytes.NewReader(msgEvent.bytes)
 				if err := m.Deserialize(reader); err != nil {
 					logger.Error(sub.topic, " : ", err)
+					return
 				}
 				// TODO: Investigate this
 				args := []reflect.Value{reflect.ValueOf(m), reflect.ValueOf(msgEvent.event)}


### PR DESCRIPTION
Closes https://rocosglobal.atlassian.net/browse/RA-643

## Changes

* Subscription jobs do not execute subscription callbacks when message deserialization fails
* The little endian byte decoder now checks that the size of any arrays to be decoded are smaller than the incoming Reader length.
  * This protects against pre-allocating erroneously sized arrays