### PR TITLE
[ch8619] - Rosgo generates schema which specify types as "bool" instead of "boolean".

### DIFF
--- a/ros/dynamic_message_json.go
+++ b/ros/dynamic_message_json.go
@@ -99,7 +99,7 @@ func (t *DynamicMessageType) generateJSONSchemaProperties(topic string) (map[str
 						} else if field.GoType == "float32" || field.GoType == "float64" {
 							jsonType = "number"
 						} else if field.GoType == "bool" {
-							jsonType = "bool"
+							jsonType = "boolean"
 						} else {
 							// Something went wrong.
 							return nil, errors.New("we haven't implemented this primitive yet")
@@ -155,7 +155,7 @@ func (t *DynamicMessageType) generateJSONSchemaProperties(topic string) (map[str
 					} else if field.GoType == "float32" || field.GoType == "float64" {
 						jsonType = "number"
 					} else if field.GoType == "bool" {
-						jsonType = "bool"
+						jsonType = "boolean"
 					} else {
 						// Something went wrong.
 						return nil, errors.New("we haven't implemented this primitive yet")


### PR DESCRIPTION
Change Rosgo so that it uses boolean instead of bool in JSON schema definition.