### PR TITLE
[ch8547] - Escaped character sequences in ROS messages cause JSON marshalling to fail.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/team-rocos/rosgo
 
-go 1.16
+go 1.17
 
 require (
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e

--- a/ros/dynamic_message_json.go
+++ b/ros/dynamic_message_json.go
@@ -540,7 +540,11 @@ func marshalArrayValue(field *libgengo.Field, v interface{}, buf *[]byte) error 
 				if i > 0 {
 					*buf = append(*buf, byte(','))
 				}
-				*buf = strconv.AppendQuote(*buf, item)
+				encoded, err := json.Marshal(item)
+				if err != nil {
+					return err
+				}
+				*buf = append(*buf, encoded...)
 			}
 		case libgengo.Time:
 			slice, ok := v.([]Time)
@@ -664,7 +668,11 @@ func marshalSingularValue(field *libgengo.Field, v interface{}, buf *[]byte) err
 		if ok == false {
 			return newTypeError(v, "string")
 		}
-		*buf = strconv.AppendQuote(*buf, value)
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		*buf = append(*buf, encoded...)
 	case libgengo.Time:
 		value, ok := v.(Time)
 		if ok == false {

--- a/ros/dynamic_message_json_test.go
+++ b/ros/dynamic_message_json_test.go
@@ -467,6 +467,14 @@ func TestDynamicMessage_marshalJSON_strings(t *testing.T) {
 	}{
 		{
 			fields: []gengo.Field{*gengo.NewField("T", "string", "s", false, 0)},
+			data:   map[string]interface{}{"s": "hexidecimal non-printing character \x00 escape"},
+		},
+		{
+			fields: []gengo.Field{*gengo.NewField("T", "string", "s", true, 1)},
+			data:   map[string]interface{}{"s": []string{"hexidecimal non-printing character \x00 escape"}},
+		},
+		{
+			fields: []gengo.Field{*gengo.NewField("T", "string", "s", false, 0)},
 			data:   map[string]interface{}{"s": "new\nline"},
 		},
 		{


### PR DESCRIPTION
Please see the ticket for more details.