### PR TITLE
GRM-2004 remove panics

### DIFF
--- a/ros/publisher.go
+++ b/ros/publisher.go
@@ -41,7 +41,7 @@ type defaultPublisher struct {
 
 func newDefaultPublisher(node *defaultNode,
 	topic string, msgType MessageType,
-	connectCallback, disconnectCallback func(SingleSubscriberPublisher)) *defaultPublisher {
+	connectCallback, disconnectCallback func(SingleSubscriberPublisher)) (*defaultPublisher, error) {
 	pub := new(defaultPublisher)
 	pub.node = node
 	pub.topic = topic
@@ -54,12 +54,12 @@ func newDefaultPublisher(node *defaultNode,
 	pub.sessionErrorChan = make(chan error, 10)
 	pub.connectCallback = connectCallback
 	pub.disconnectCallback = disconnectCallback
-	if listener, err := listenRandomPort(node.listenIP, 10); err != nil {
-		panic(err)
+	if listener, err := listenRandomPort(node.listenIP); err != nil {
+		return nil, err
 	} else {
 		pub.listener = listener
 	}
-	return pub
+	return pub, nil
 }
 
 func (pub *defaultPublisher) start(wg *sync.WaitGroup) {

--- a/ros/service_server.go
+++ b/ros/service_server.go
@@ -36,7 +36,7 @@ type defaultServiceServer struct {
 func newDefaultServiceServer(node *defaultNode, service string, srvType ServiceType, handler interface{}) *defaultServiceServer {
 	logger := node.log
 	server := new(defaultServiceServer)
-	if listener, err := listenRandomPort(node.listenIP, 10); err != nil {
+	if listener, err := listenRandomPort(node.listenIP); err != nil {
 		logger.Error().Err(err).Msg("failed to listen to random port")
 		return nil
 	} else {

--- a/ros/temporal.go
+++ b/ros/temporal.go
@@ -12,8 +12,11 @@ func normalizeTemporal(sec int64, nsec int64) (uint32, uint32) {
 		nsec = nsec%SecondInNanosecond + SecondInNanosecond
 	}
 
-	if sec < 0 || sec > maxUint32 {
-		panic("Time is out of range")
+	if sec < 0 {
+		sec = 0
+	}
+	if sec > maxUint32 {
+		sec = maxUint32
 	}
 
 	return uint32(sec), uint32(nsec)

--- a/stub.go
+++ b/stub.go
@@ -2,7 +2,7 @@ package rosgo
 
 // stub exists solely so that the top level package is a validate Go module.
 func stub() {
-	panic( "calling a stub.")
+	panic("calling a stub.")
 }
 
 // ALL DONE.

--- a/xmlrpc/xmlrpc.go
+++ b/xmlrpc/xmlrpc.go
@@ -175,13 +175,12 @@ func nextTag(d *xml.Decoder) (xml.StartElement, error) {
 			return elem, nil
 		}
 	}
-	panic("not reached")
 }
 
 func expectNextTag(d *xml.Decoder, name string) (xml.StartElement, error) {
-	tag, e := nextTag(d)
-	if e != nil {
-		return xml.StartElement{}, e
+	tag, err := nextTag(d)
+	if err != nil {
+		return xml.StartElement{}, err
 	}
 	if tag.Name.Local == name {
 		return tag, nil
@@ -493,7 +492,8 @@ func parseResponse(d *xml.Decoder) (ok bool, result interface{}, e error) {
 
 // Call a XMLRPC API in a remote host.
 // Args:
-//   url string: URL of the remote host
+//
+//	url string: URL of the remote host
 func (client *XMLClient) Call(url string, method string, args ...interface{}) (res interface{}, e error) {
 
 	var buffer bytes.Buffer
@@ -545,28 +545,24 @@ func (client *XMLClient) Call(url string, method string, args ...interface{}) (r
 	}
 }
 
-//type Method func (args ...interface{}) (interface{}, error)
+// type Method func (args ...interface{}) (interface{}, error)
 type Method interface{}
 
-//
 type Handler struct {
 	mapping map[string]Method
 	wait    sync.WaitGroup
 }
 
-//
 func NewHandler(mapping map[string]Method) *Handler {
 	handler := new(Handler)
 	handler.mapping = mapping
 	return handler
 }
 
-//
 func (self *Handler) WaitForShutdown() {
 	self.wait.Wait()
 }
 
-//
 func (self *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	self.wait.Add(1)
 	defer self.wait.Done()

--- a/xmlrpc/xmlrpc_test.go
+++ b/xmlrpc/xmlrpc_test.go
@@ -684,8 +684,7 @@ func (h *myDispatcher) addTwoInts(a int32, b int32) (int32, error) {
 func TestServer(t *testing.T) {
 	listener, err := net.Listen("tcp", ":19937")
 	if err != nil {
-		panic(err)
-		return
+		t.Fatal(err)
 	}
 	d := myDispatcher{2}
 	m := map[string]Method{"addTwoInts": d.addTwoInts}


### PR DESCRIPTION
Closes [GRM-2004](https://dronedeploy.atlassian.net/browse/GRM-2004)

As part of cloud agent preparation, this PR removes unnecessary panics from `rosgo`

Also updates the `listenRandomPort` to use the inbuilt port selection.

Note: there are still `panic` routines in rosgo, however they are handled using `recover`.

## Demonstration

Ros component still working correctly

![image](https://github.com/team-rocos/rosgo/assets/4222666/f791d776-8baf-41ad-b2bf-e2db25d4133c)


[GRM-2004]: https://dronedeploy.atlassian.net/browse/GRM-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ